### PR TITLE
fix(coc): remove residual Rust contamination from red team audit

### DIFF
--- a/.claude/rules/connection-pool.md
+++ b/.claude/rules/connection-pool.md
@@ -1,0 +1,300 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.rb"
+---
+
+# Connection Pool Safety Rules
+
+## Scope
+
+These rules apply to all code that uses DataFlow, creates database connections, or configures application workers. Covers Python and Ruby applications using `kailash-enterprise`.
+
+**Applies to**: `**/*.py`, `**/*.rb`
+
+## MUST Rules
+
+### 1. Never Use Default Pool Size in Production
+
+MUST set `DATAFLOW_MAX_CONNECTIONS` environment variable. The default pool size (typically 25 per worker) will exhaust PostgreSQL's connection limit on small-to-medium instances.
+
+**Formula**: `pool_size = postgres_max_connections / num_workers * 0.7`
+
+| Instance Size   | `max_connections` | Workers | `DATAFLOW_MAX_CONNECTIONS` |
+| --------------- | ----------------- | ------- | -------------------------- |
+| t2.micro        | 87                | 2       | 30                         |
+| t2.small        | 150               | 2       | 50                         |
+| t2.medium       | 150               | 2       | 50                         |
+| t3.medium       | 150               | 4       | 25                         |
+| r5.large        | 1000              | 4       | 175                        |
+
+#### Python
+
+```python
+# WRONG — relies on default pool size
+import kailash
+df = kailash.DataFlow("postgresql://...")
+
+# RIGHT — explicit pool size from environment
+import os, kailash
+df = kailash.DataFlow(
+    os.environ["DATABASE_URL"],
+    max_connections=int(os.environ.get("DATAFLOW_MAX_CONNECTIONS", "10"))
+)
+```
+
+#### Ruby
+
+```ruby
+# WRONG — relies on default pool size
+config = Kailash::DataFlow::Config.new("postgresql://...")
+df = Kailash::DataFlow.new(config)
+
+# RIGHT — explicit pool size from environment
+config = Kailash::DataFlow::Config.new(ENV.fetch("DATABASE_URL"))
+config.max_connections = ENV.fetch("DATAFLOW_MAX_CONNECTIONS", "10").to_i
+df = Kailash::DataFlow.new(config)
+```
+
+**Enforced by**: deployment-specialist agent, pool-safety skill
+**Violation**: BLOCK deployment
+
+### 2. Never Query DB Per-Request in Middleware
+
+MUST NOT call DataFlow workflows (ReadUser, ReadSession, etc.) in middleware that runs on every HTTP request. This creates N+1 connection usage where N is concurrent requests, rapidly exhausting the pool.
+
+#### Python — Detection patterns
+
+```python
+# WRONG — DB query runs on EVERY request
+class AuthMiddleware:
+    async def __call__(self, request):
+        reg = kailash.NodeRegistry()
+        builder = kailash.WorkflowBuilder()
+        builder.add_node("ReadUser", "read", {"filter": {"token": token}})
+        rt = kailash.Runtime(reg)
+        result = rt.execute(builder.build(reg))  # Pool checkout per request!
+        request.state.user = result["results"]["read"]
+```
+
+#### Python — Correct patterns
+
+```python
+# RIGHT — JWT claims, no DB hit
+class AuthMiddleware:
+    async def __call__(self, request):
+        token = request.headers.get("Authorization", "").removeprefix("Bearer ")
+        claims = jwt.decode(token, key=os.environ["JWT_SECRET"], algorithms=["HS256"])
+        request.state.user_id = claims["sub"]
+        request.state.permissions = claims.get("permissions", [])
+
+# RIGHT — In-memory cache with TTL for session data
+from cachetools import TTLCache
+
+_session_cache = TTLCache(maxsize=1000, ttl=300)  # 5-minute TTL
+
+class AuthMiddleware:
+    async def __call__(self, request):
+        token = extract_token(request)
+        if token in _session_cache:
+            request.state.user = _session_cache[token]
+        else:
+            user = await self._fetch_user(token)  # DB hit only on cache miss
+            _session_cache[token] = user
+            request.state.user = user
+```
+
+#### Ruby — Detection patterns
+
+```ruby
+# WRONG — DB query runs on EVERY request
+class AuthMiddleware
+  def call(env)
+    Kailash::Registry.open do |registry|
+      builder = Kailash::WorkflowBuilder.new
+      builder.add_node("ReadUser", "read", { "token" => token })
+      workflow = builder.build(registry)
+      Kailash::Runtime.open(registry) do |rt|
+        result = rt.execute(workflow, {})  # Pool checkout per request!
+      end
+    end
+  end
+end
+```
+
+#### Ruby — Correct patterns
+
+```ruby
+# RIGHT — JWT claims, no DB hit
+class AuthMiddleware
+  def call(env)
+    token = env["HTTP_AUTHORIZATION"]&.delete_prefix("Bearer ")
+    claims = JWT.decode(token, ENV.fetch("JWT_SECRET"), true, algorithm: "HS256").first
+    env["user_id"] = claims["sub"]
+    @app.call(env)
+  end
+end
+```
+
+**Enforced by**: intermediate-reviewer agent, pool-safety skill
+**Violation**: BLOCK commit
+
+### 3. Health Checks Must Not Use Application Pool
+
+MUST use a lightweight query or a dedicated connection for health checks, never a full DataFlow workflow. Health checks run every 10-30 seconds per load balancer target — if they use the application pool, they consume connections continuously.
+
+#### Python
+
+```python
+# WRONG — full DataFlow workflow for health check
+@app.get("/health")
+async def health():
+    builder = kailash.WorkflowBuilder()
+    builder.add_node("ListUser", "check", {"limit": 1})
+    result = rt.execute(builder.build(reg))
+    return {"status": "ok"}
+
+# RIGHT — lightweight raw query
+@app.get("/health")
+async def health():
+    try:
+        await db.execute_raw("SELECT 1")
+        return {"status": "ok"}
+    except Exception:
+        return JSONResponse({"status": "error"}, status_code=503)
+```
+
+#### Ruby
+
+```ruby
+# WRONG
+get "/health" do
+  builder = Kailash::WorkflowBuilder.new
+  builder.add_node("ListUser", "check", { "limit" => 1 })
+  # ...
+
+# RIGHT
+get "/health" do
+  ActiveRecord::Base.connection.execute("SELECT 1")
+  { status: "ok" }.to_json
+rescue StandardError => e
+  status 503
+  { status: "error", detail: e.message }.to_json
+end
+```
+
+**Enforced by**: deployment-specialist agent
+**Violation**: BLOCK deployment
+
+### 4. Verify Pool Math at Deployment
+
+Before deploying, MUST verify this inequality holds:
+
+```
+DATAFLOW_MAX_CONNECTIONS x num_workers <= postgres_max_connections x 0.7
+```
+
+The 0.7 factor reserves 30% of connections for admin tasks, migrations, monitoring, and connection spikes.
+
+**Example**:
+- PostgreSQL `max_connections = 150` (t2.medium default)
+- Puma workers = 4
+- `DATAFLOW_MAX_CONNECTIONS = 25`
+- Check: `25 x 4 = 100 <= 150 x 0.7 = 105` — PASS
+
+**Counter-example** (the bug that created this rule):
+- PostgreSQL `max_connections = 150`
+- Gunicorn workers = 4
+- `DATAFLOW_MAX_CONNECTIONS = 50` (or default)
+- Check: `50 x 4 = 200 > 105` — FAIL. Pool exhaustion under load.
+
+**Enforced by**: pool-safety skill during `/deploy`
+**Violation**: BLOCK deployment
+
+### 5. Connection Timeout Must Be Set
+
+MUST set a connection acquisition timeout. Without it, requests queue indefinitely when the pool is exhausted, causing cascading timeouts.
+
+#### Python
+
+```python
+# RIGHT — timeout after 5 seconds
+df = kailash.DataFlow(
+    os.environ["DATABASE_URL"],
+    max_connections=int(os.environ.get("DATAFLOW_MAX_CONNECTIONS", "10")),
+    connection_timeout=5  # seconds
+)
+```
+
+#### Ruby
+
+```ruby
+# RIGHT — timeout after 5 seconds
+config = Kailash::DataFlow::Config.new(ENV.fetch("DATABASE_URL"))
+config.max_connections = ENV.fetch("DATAFLOW_MAX_CONNECTIONS", "10").to_i
+config.connection_timeout = 5  # seconds
+df = Kailash::DataFlow.new(config)
+```
+
+### 6. Workers Must Share Pool
+
+All coroutines/threads within a single worker MUST share one pool. MUST NOT create a new DataFlow/pool instance per request or per route handler.
+
+#### Python
+
+```python
+# WRONG — new pool per request
+@app.post("/users")
+async def create_user(data: UserCreate):
+    df = kailash.DataFlow(os.environ["DATABASE_URL"])  # New pool!
+
+# RIGHT — application-level singleton
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app):
+    app.state.df = kailash.DataFlow(
+        os.environ["DATABASE_URL"],
+        max_connections=int(os.environ.get("DATAFLOW_MAX_CONNECTIONS", "10"))
+    )
+    yield
+    await app.state.df.close()
+```
+
+#### Ruby
+
+```ruby
+# WRONG — new connection per request
+get "/users" do
+  config = Kailash::DataFlow::Config.new(ENV.fetch("DATABASE_URL"))
+  df = Kailash::DataFlow.new(config)  # New pool!
+
+# RIGHT — shared at application level
+configure do
+  set :df, Kailash::DataFlow.new(
+    Kailash::DataFlow::Config.new(ENV.fetch("DATABASE_URL")).tap { |c|
+      c.max_connections = ENV.fetch("DATAFLOW_MAX_CONNECTIONS", "10").to_i
+    }
+  )
+end
+```
+
+## MUST NOT Rules
+
+### 1. No Unbounded Connection Creation
+
+MUST NOT create database connections in loops or recursive functions without pool limits.
+
+### 2. No Pool Size From User Input
+
+MUST NOT allow pool size to be set from user-controlled input (API parameters, form fields).
+
+### 3. No Separate ConnectionManagers Per Store
+
+MUST NOT create a new ConnectionManager/DataFlow instance for each store. All stores within a worker MUST share the same pool.
+
+## Cross-References
+
+- `rules/deployment.md` — Production deployment checklist
+- `rules/patterns.md` — DataFlow framework patterns (Python + Ruby)
+- `skills/project/pool-safety.md` — Deployment verification skill

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -25,7 +25,6 @@ Every bug fix MUST include a regression test BEFORE the fix is merged or release
 1. When a bug is reported, the FIRST step is writing a test that REPRODUCES the bug
 2. The test MUST fail before the fix and pass after
 3. Regression test location depends on language:
-   - Rust: `tests/regression_*.rs` in the affected crate
    - Python: `tests/regression/test_issue_*.py`
    - Ruby: `spec/regression/issue_*_spec.rb`
 4. The test name includes the issue number (e.g., `issue_42_user_creation_drops_pk`)

--- a/.claude/skills/02-dataflow/dataflow-troubleshooting.md
+++ b/.claude/skills/02-dataflow/dataflow-troubleshooting.md
@@ -213,13 +213,14 @@ if "step1" in existing:
 
 | Feature                            | Pure Python SDK    | Rust Binding                       |
 | ---------------------------------- | ------------------ | ---------------------------------- |
-| Auto-generated CRUD nodes          | Yes (11 per model) | No — use SQLQueryNode              |
-| Inspector / DebugAgent             | Yes                | No                                 |
+| Auto-generated CRUD nodes          | Yes (11 per model) | No -- use SQLQueryNode             |
+| DataFlowInspector                  | Yes                | Yes                                |
+| DataFlowExpress                    | Yes                | Yes                                |
+| DebugAgent                         | Yes                | No                                 |
 | CLI commands (`dataflow validate`) | Yes                | No                                 |
 | DF-XXX error codes                 | Yes                | RuntimeError messages              |
 | `DataFlow(url, test_mode=True)`    | Yes                | Yes (also `DataFlowConfig.test()`) |
 | Schema cache metrics               | Yes                | No                                 |
-| DataFlowExpress                    | Yes                | No                                 |
 
 ## Related
 

--- a/.claude/skills/project/pool-safety.md
+++ b/.claude/skills/project/pool-safety.md
@@ -1,0 +1,139 @@
+# Connection Pool Safety Verification
+
+Pre-deployment skill that verifies database connection pool configuration is safe for production. Invoke during `/deploy` or manually before any deployment. Covers Python and Ruby applications using `kailash-enterprise`.
+
+## When to Run
+
+- During `/deploy` phase — automatically as part of the deployment checklist
+- Before scaling workers up or down
+- After changing database instance size
+- When diagnosing connection timeout errors in production
+
+## Step 1: Check DATAFLOW_MAX_CONNECTIONS
+
+Search for `DATAFLOW_MAX_CONNECTIONS` in the project's `.env`, `.env.production`, `docker-compose.yml`, and deployment manifests.
+
+```bash
+# Check all env files and deployment configs
+grep -r "DATAFLOW_MAX_CONNECTIONS" .env* docker-compose*.yml deploy/ k8s/ config/ 2>/dev/null
+
+# Check if it's used in Python code
+grep -rn "DATAFLOW_MAX_CONNECTIONS" src/ app/ lib/ --include="*.py" 2>/dev/null
+
+# Check if it's used in Ruby code
+grep -rn "DATAFLOW_MAX_CONNECTIONS" src/ app/ lib/ --include="*.rb" 2>/dev/null
+```
+
+**If not found**: BLOCK deployment. Add to `.env`:
+
+```
+DATAFLOW_MAX_CONNECTIONS=10
+```
+
+**If found**: Record the value for pool math verification in Step 3.
+
+## Step 2: Scan for Per-Request DB Queries in Middleware
+
+Search for DataFlow workflow execution inside middleware, decorators, or request hooks.
+
+### Python
+
+```bash
+# Find middleware files
+find . -name "middleware*.py" -o -name "*middleware*.py" | head -20
+
+# Search for DB queries in middleware
+grep -rn "execute\|Runtime\|DataFlow\|ReadUser\|ReadSession\|WorkflowBuilder\|add_node.*Read" \
+  $(find . -name "middleware*.py" -o -name "*middleware*.py" 2>/dev/null) 2>/dev/null
+```
+
+### Ruby
+
+```bash
+# Find middleware files
+find . -name "*middleware*.rb" | head -20
+
+# Search for DB queries in middleware
+grep -rn "Kailash::Runtime\|Kailash::DataFlow\|WorkflowBuilder\|add_node.*Read" \
+  $(find . -name "*middleware*.rb" 2>/dev/null) 2>/dev/null
+```
+
+**If found**: BLOCK deployment. Report each file and line number. The fix is to replace DB queries with:
+- JWT claim extraction (preferred for auth)
+- In-memory TTL cache (`cachetools.TTLCache` in Python, `lru_cache` gem in Ruby)
+- Redis cache for distributed deployments
+
+## Step 3: Verify Pool Math
+
+Collect these values and verify the inequality:
+
+1. **`DATAFLOW_MAX_CONNECTIONS`** — from Step 1
+2. **`num_workers`** — from server config, Dockerfile, or deployment manifest
+
+```bash
+# Check Gunicorn/uvicorn config (Python)
+grep -rn "workers\|WEB_CONCURRENCY" gunicorn*.py Procfile docker-compose*.yml 2>/dev/null
+
+# Check Puma config (Ruby)
+grep -rn "workers\|WEB_CONCURRENCY" config/puma.rb Procfile 2>/dev/null
+```
+
+3. **`postgres_max_connections`** — from RDS/CloudSQL config or PostgreSQL settings
+
+**Verify**: `DATAFLOW_MAX_CONNECTIONS x num_workers <= postgres_max_connections x 0.7`
+
+| Variable                    | Value    | Source                  |
+| --------------------------- | -------- | ----------------------- |
+| `DATAFLOW_MAX_CONNECTIONS`  | ___      | `.env` / deploy config  |
+| `num_workers`               | ___      | Server config           |
+| `postgres_max_connections`  | ___      | RDS/CloudSQL/pg config  |
+| **Pool total**              | ___ x ___ = ___ |                   |
+| **Safe limit (70%)**        | ___ x 0.7 = ___ |                   |
+| **Result**                  | PASS/FAIL |                         |
+
+**If FAIL**: Reduce `DATAFLOW_MAX_CONNECTIONS` or reduce workers or increase `postgres_max_connections`.
+
+## Step 4: Check Health Endpoint
+
+```bash
+# Find health check endpoints (Python)
+grep -rn "health\|healthz\|readyz\|liveness" src/ app/ --include="*.py" 2>/dev/null
+
+# Find health check endpoints (Ruby)
+grep -rn "health\|healthz\|readyz\|liveness" app/ lib/ config/ --include="*.rb" 2>/dev/null
+
+# Check if health endpoints use DataFlow workflows
+grep -A 10 "health" $(grep -rl "health\|healthz" src/ app/ lib/ --include="*.py" --include="*.rb" 2>/dev/null) 2>/dev/null | \
+  grep -i "workflow\|dataflow\|execute\|add_node\|Runtime"
+```
+
+**If health endpoints use DataFlow workflows**: WARN. Replace with `SELECT 1` raw query.
+
+## Step 5: Check for Pool-Per-Request Anti-Pattern
+
+```bash
+# Find DataFlow/pool instantiation inside route handlers (Python)
+grep -rn "DataFlow(\|create_pool" src/ app/ --include="*.py" 2>/dev/null
+
+# Find DataFlow/pool instantiation inside route handlers (Ruby)
+grep -rn "DataFlow.new\|ConnectionPool.new" app/ lib/ --include="*.rb" 2>/dev/null
+```
+
+**If pool is instantiated inside route handlers or non-singleton functions**: BLOCK. Move to application startup/lifespan.
+
+## Output Format
+
+Report findings as a checklist:
+
+```
+## Pool Safety Report
+
+- [x] DATAFLOW_MAX_CONNECTIONS is set: 25
+- [x] Pool math verified: 25 x 4 = 100 <= 105 (150 x 0.7) — PASS
+- [x] No per-request DB queries in middleware
+- [x] Health check uses lightweight query
+- [x] DataFlow pool is application-level singleton
+- [ ] ISSUE: middleware/auth.py:42 — ReadUser workflow in AuthMiddleware
+
+Status: PASS / BLOCKED (fix issues above)
+```


### PR DESCRIPTION
## Summary

Red team audit of the RS COC template after PR #4 repair. Found and fixed residual Rust BUILD-internal content that survived the repair:

- **connection-pool.md**: Removed Rust `PgPoolOptions`/`std::env::var` code blocks and `**/*.rs` path scope (3 Rust code blocks)
- **testing.md**: Removed `Rust: tests/regression_*.rs in the affected crate` — BUILD-internal path
- **dataflow-troubleshooting.md**: Fixed factual errors in the SDK comparison table — `DataFlowInspector` and `DataFlowExpress` DO exist in the Rust binding (verified against `.pyi`)
- **pool-safety.md**: Removed Rust grep patterns, `PgPoolOptions` references, `moka` crate mention, and `**/*.rs` search commands

Also cleaned up 2 stale `coc-sync/` remote branches from previous sync attempts.

## Test plan

- [x] `grep -r '```rust' .claude/ scripts/` returns no matches
- [x] `grep -r 'PgPoolOptions\|std::env::var\|\.rs\b' .claude/rules/` returns no matches  
- [x] `grep -r 'cargo ' .claude/ scripts/` returns no matches
- [x] DataFlowInspector/DataFlowExpress verified to exist in `bindings/kailash-python/kailash.pyi`
- [x] No stale remote branches remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)