### PR TITLE
chore(coc): add SDK version awareness to /sync and /codify

### DIFF
--- a/.claude/commands/codify.md
+++ b/.claude/commands/codify.md
@@ -73,12 +73,15 @@ After artifacts are updated and validated locally, create a proposal for upstrea
 **DO NOT sync directly to COC template repos.** All distribution flows through kailash/ via `/sync`.
 
 1. Create `.claude/.proposals/` directory if it doesn't exist
-2. Generate `.claude/.proposals/latest.yaml` listing all artifact changes:
+2. Read the SDK version from `pyproject.toml` (py) or `Cargo.toml` (rs) and the COC artifact version from `.claude/VERSION`
+3. Generate `.claude/.proposals/latest.yaml` listing all artifact changes:
 
 ```yaml
 source_repo: kailash-py # or kailash-rs
 codify_date: YYYY-MM-DD
 codify_session: "type(scope): description of work"
+sdk_version: "2.2.1"  # from pyproject.toml or Cargo.toml
+coc_version: "1.0.0"  # from .claude/VERSION
 
 changes:
   - file: relative/path/to/artifact.md

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -45,11 +45,29 @@ Search paths (in order):
 2. `../../kailash/{template}/` (kailash parent)
 3. Ask user for path
 
-### 3. Compare freshness
+### 3. Check SDK version compatibility
+
+Read this project's SDK version from `pyproject.toml` (look for `kailash-enterprise`) or `Gemfile` (look for `kailash` gem) or `Cargo.toml` (look for `kailash` dependency). Read the template's VERSION file for the `build_version`.
+
+Report both in the sync header:
+```
+Project SDK: kailash-enterprise==1.0.0 (from pyproject.toml)
+Template COC: 1.0.0 (from template .claude/VERSION)
+```
+
+If the template artifacts were codified from a newer SDK version than the project uses, warn:
+```
+⚠ Template artifacts may reference SDK features newer than your installed version.
+  Consider upgrading your SDK dependency.
+```
+
+This is informational — sync proceeds regardless.
+
+### 4. Compare freshness
 
 Compare `.coc-sync-marker` timestamps. If already fresh: "Already up to date."
 
-### 4. Pull and merge
+### 5. Pull and merge
 
 **Updated from template** (shared artifacts):
 
@@ -80,17 +98,17 @@ Compare `.coc-sync-marker` timestamps. If already fresh: "Already up to date."
 - `scripts/hooks/*.js` — updated
 - `scripts/hooks/lib/*.js` — updated
 
-### 5. Verify integrity
+### 6. Verify integrity
 
 - Every hook in `settings.json` has a corresponding script
 - Every `require("./lib/...")` has a matching lib file
 
-### 6. Update tracking
+### 7. Update tracking
 
 - Write `.claude/.coc-sync-marker` with timestamp and template source
 - If `.claude/VERSION` exists, update `upstream.version` to match the template's VERSION version (so future session-start checks report correctly)
 
-### 7. Report
+### 8. Report
 
 ```
 ## Sync Complete: kailash-coc-claude-rs → this repo


### PR DESCRIPTION
## Summary
- `/sync` now reads `pyproject.toml`/`Cargo.toml` SDK version and warns if template artifacts reference newer features
- `/codify` now stamps proposals with `sdk_version` and `coc_version`

## Test plan
- [ ] Commands are under 150 lines
- [ ] Downstream `/sync` includes SDK version check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)