### PR TITLE
chore(sync): Gate 1 rs v3.8.0 cross-ref fixes + SKILL.md indexes

### DIFF
--- a/.claude/skills/01-core-sdk/SKILL.md
+++ b/.claude/skills/01-core-sdk/SKILL.md
@@ -1,177 +1,86 @@
----
-name: core-sdk
-description: "Kailash Core SDK fundamentals including workflow creation, node patterns, connections, runtime execution, parameter passing, error handling, cyclic workflows, async patterns, MCP integration, and installation. Use when asking about 'workflow basics', 'core sdk', 'create workflow', 'workflow builder', 'node patterns', 'connections', 'runtime', 'parameters', 'imports', 'installation', 'getting started', 'workflow execution', 'async workflows', 'error handling', 'cyclic workflows', 'PythonCode node', 'SwitchNode', or 'MCP integration'."
----
+# Kailash Workspace Crate Reference
 
-# Kailash Core SDK - Foundational Skills
+Quick reference for all crates in the workspace. For full API docs, read the crate source or run `cargo doc --workspace --no-deps`.
 
-Comprehensive guide to Kailash Core SDK fundamentals for workflow automation and integration.
+## Crate Map
 
-## Features
+| Crate                  | Purpose                | Key Types                                                                                        | Skill                        |
+| ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------- |
+| **kailash-value**      | Universal data type    | `Value` enum, `ValueMap` (`BTreeMap<Arc<str>, Value>`)                                           | (this file)                  |
+| **kailash-core**       | Workflow engine        | `Node` trait, `WorkflowBuilder`, `Runtime`, `AuditLog`, `EventBus`                               | (this file)                  |
+| **kailash-nodes**      | 139+ built-in nodes    | Control flow, HTTP, SQL, AI, Auth, Security, RAG, Edge                                           | `skills/08-nodes-reference/` |
+| **kailash-macros**     | Proc-macros            | `#[kailash_node]`, `#[dataflow::model]`, `#[derive(Signature)]`                                  | (this file)                  |
+| **kailash-plugin**     | WASM + native plugins  | `wasmtime` sandbox, `libloading` cdylib                                                          | (this file)                  |
+| **kailash-dataflow**   | Database framework     | `DataFlow`, `QueryDialect`, `MigrationManager`, 11 nodes/model                                   | `skills/02-dataflow/`        |
+| **kailash-nexus**      | Multi-channel platform | `NexusEngine`, axum handlers, tower middleware, K8s probes                                       | `skills/03-nexus/`           |
+| **kailash-kaizen**     | AI agent SDK           | `BaseAgent`, TAOD loop, `LlmClient`, `CostTracker`                                               | `skills/04-kaizen/`          |
+| **kaizen-agents**      | LLM orchestration      | `GovernedSupervisor`, `PlanMonitor`, hydration, CallerEvent streaming, TaodRunner Python binding | `skills/32-kaizen-agents/`   |
+| **eatp**               | Trust protocol         | Ed25519 keys, CareChain, delegation, reasoning traces                                            | `skills/26-eatp-reference/`  |
+| **trust-plane**        | Trust environment      | `TrustProject`, `StrictEnforcer`, shadow mode                                                    | `skills/29-trust-plane/`     |
+| **kailash-governance** | Governance primitives  | `GovernanceEngine`, D/T/R, envelopes, LCA, DelegationBuilder, RBAC matrix                        | `skills/29-pact/`            |
+| **kailash-pact**       | PACT governance        | Re-exports governance, adds agent, MCP, YAML, SQLite                                             | `skills/29-pact/`            |
+| **kailash-enterprise** | Enterprise features    | RBAC, ABAC, audit, multi-tenancy, human competencies                                             | `skills/05-enterprise/`      |
 
-The Core SDK provides the foundational building blocks for creating custom workflows with fine-grained control:
+## kailash-value
 
-- **110+ Workflow Nodes**: Pre-built nodes for AI, API, database, file operations, logic, and more
-- **WorkflowBuilder API**: String-based workflow construction with type safety
-- **Dual Runtime Support**: AsyncLocalRuntime (Docker/FastAPI) and LocalRuntime (CLI/scripts)
-- **Advanced Patterns**: Cyclic workflows, conditional execution, error handling
-- **MCP Integration**: Built-in Model Context Protocol support
-- **Parameter Passing**: Flexible data flow between nodes
-- **Zero Configuration**: Auto-detection of runtime context
-- **Production Ready**: Enterprise features including monitoring, validation, and debugging
-
-## Quick Start
-
-```python
-from kailash.workflow.builder import WorkflowBuilder
-from kailash.runtime.local import LocalRuntime
-
-workflow = WorkflowBuilder()
-workflow.add_node("NodeName", "id", {"param": "value"})
-
-# Use context manager for proper resource cleanup (recommended)
-with LocalRuntime() as runtime:
-    results, run_id = runtime.execute(workflow.build())
+```rust
+pub enum Value {
+    Null, Bool(bool), Integer(i64), Float(f64),
+    String(Arc<str>), Bytes(Bytes),
+    Array(Vec<Value>), Object(BTreeMap<Arc<str>, Value>),
+}
+pub type ValueMap = BTreeMap<Arc<str>, Value>;
 ```
 
-## Reference Documentation
+Design: `Arc<str>` zero-cost cloning, `BTreeMap` deterministic iteration, `Bytes` for binary. Feature: `arrow` enables `From<arrow::RecordBatch>`.
 
-### Getting Started
+## kailash-core
 
-- **[workflow-quickstart](workflow-quickstart.md)** - Create basic workflows with WorkflowBuilder
-- **[kailash-installation](kailash-installation.md)** - Installation and setup guide
-- **[kailash-imports](kailash-imports.md)** - Import patterns and module organization
+**Node trait**: Single async trait -- `type_name()`, `input_params()`, `output_params()`, `execute()`.
 
-### Core Patterns
+**WorkflowBuilder**: `add_node(type, id, config)` -> `connect(src, out, dst, in)` -> `build(&registry)?` (validation boundary).
 
-- **[node-patterns-common](node-patterns-common.md)** - Common node usage patterns
-- **[connection-patterns](connection-patterns.md)** - Linking nodes and data flow
-- **[param-passing-quick](param-passing-quick.md)** - Parameter passing strategies
-- **[runtime-execution](runtime-execution.md)** - Executing workflows (sync/async)
-- **[runtime-lifecycle](runtime-lifecycle.md)** - Runtime lifecycle, ref counting, acquire/release, context managers
+**Runtime**: `execute(&workflow, inputs).await` (async) or `execute_sync(&workflow, inputs)` (sync wrapper). Returns `ExecutionResult { results, run_id, metadata }`.
 
-### Advanced Topics
+**RuntimeConfig**: `strict_input_validation: bool` (default false).
 
-- **[async-workflow-patterns](async-workflow-patterns.md)** - Asynchronous workflow execution
-- **[async-resource-safety](async-resource-safety.md)** - `__del__` hardening, double-check locking, pool lifecycle, static analysis guardrails
-- **[cycle-workflows-basics](cycle-workflows-basics.md)** - Cyclic workflow patterns
-- **[error-handling-patterns](error-handling-patterns.md)** - Error management strategies
-- **[switchnode-patterns](switchnode-patterns.md)** - Conditional routing with SwitchNode
-- **[pythoncode-best-practices](pythoncode-best-practices.md)** - PythonCode node best practices
-- **[mcp-integration-guide](mcp-integration-guide.md)** - Model Context Protocol integration
+**Resources**: `PoolRegistry` (global sharing) -> `ResourceRegistry` (LIFO shutdown via `runtime.shutdown().await`).
 
-## Key Concepts
+**AuditLog** (v3.3): Append-only SHA-256 hash chain, `verify_chain()`, retention policies, legal hold.
 
-### Canonical Node Pattern (4-Parameter)
+**EventBus** (v3.3): `DomainEventBus` trait, `InMemoryEventBus` (DashMap), `EventBridge`.
 
-**This is the single source of truth for node configuration.** All other skills reference this section.
+**Telemetry**: Feature-gated `telemetry` -- `init_telemetry()`, `workflow_span()`, `node_span()`.
 
-```python
-workflow.add_node(
-    "NodeClassName",  # 1. Node type (PascalCase, string)
-    "unique_node_id", # 2. Unique ID (snake_case, string)
-    {                 # 3. Configuration dict
-        "param1": "value",
-        "param2": 123
-    },
-    connections=[]    # 4. Optional: input connections
-)
-```
+## kailash-nodes
 
-| Parameter   | Type | Description                          | Example                         |
-| ----------- | ---- | ------------------------------------ | ------------------------------- |
-| Node type   | str  | The node class name (PascalCase)     | `"LLMNode"`, `"HTTPRequest"`    |
-| Node ID     | str  | Unique identifier (snake_case)       | `"fetch_data"`, `"process_1"`   |
-| Config      | dict | Node-specific configuration          | `{"url": "..."}`                |
-| Connections | list | Optional input connections (4-tuple) | `[("src", "out", "dst", "in")]` |
+139 nodes (binding) / ~145+ (workspace with `excel`, `pdf`, `wasm` features). Categories: control_flow(8), transform(9), http(7), sql(3), file(7), ai(9), auth(10), security(12), monitoring(10), edge(14), rag(7), enterprise(8), embedded(4), + DataFlow-generated (11/model).
 
-**Connection Methods**:
+## kailash-dataflow
 
-```python
-# Method 1: add_connection (4-positional params - explicit)
-workflow.add_connection("read_file", "content", "transform", "input")
+sqlx-backed. `#[dataflow::model]` generates 11 node types. Multi-database (SQLite/PG/MySQL) via `QueryDialect::from_url()`. Field validation (7 validators), data classification, `LazyDataFlow`, `MigrationManager`, `QueryEngine`.
 
-# Method 2: connect (flexible API with keyword args)
-workflow.connect("read_file", "transform", from_output="content", to_input="input")
+**Gotchas**: Never set `created_at`/`updated_at` manually. `Create` uses flat params. `Update` uses `filter` + `fields`. PK must be `id`. `soft_delete` only affects DELETE.
 
-# Method 3: connect with mapping (multiple outputs)
-workflow.connect("node1", "node2", mapping={"content": "input", "meta": "metadata"})
-```
+## kailash-nexus
 
-### WorkflowBuilder Pattern
+axum + tower. Handler pattern, Presets (None/Lightweight/Standard/SaaS/Enterprise), enterprise middleware (Auth JWT RS256, CSRF, Audit, Metrics), K8s probes, `OpenApiGenerator`, MCP channel, AgentUI SSE.
 
-- String-based node API: `workflow.add_node("NodeName", "id", {})`
-- Always call `.build()` before execution
-- Never `workflow.execute(runtime)` - always `runtime.execute(workflow.build())`
+## kailash-kaizen + kaizen-agents
 
-### Runtime Selection
+SDK (`kailash-kaizen`): BaseAgent TAOD loop, `#[derive(Signature)]`, LLM providers (OpenAI/Anthropic/Google/Mistral/Cohere), memory, trust framework (GovernedAgent, CircuitBreaker, ShadowEnforcer), CostTracker.
 
-- **AsyncLocalRuntime**: For Docker/FastAPI (async contexts) - async-first, no threading, 10-100x faster
-- **LocalRuntime**: For CLI/scripts (sync contexts) - synchronous execution with thread support
-- **get_runtime()**: Auto-detection helper that selects appropriate runtime based on context
+Orchestration (`kaizen-agents`): GovernedSupervisor, PlanMonitor, gradient (G1-G9), hydration (TF-IDF, search_tools), CallerEvent streaming (6 variants + wire types), 9 governance modules, audit trail. See `skills/32-kaizen-agents/`.
 
-Both runtimes return identical structure: `(results, run_id)` tuple.
+## Language Bindings
 
-### Runtime Architecture
+| Binding | Technology           | Install                                    |
+| ------- | -------------------- | ------------------------------------------ |
+| Python  | PyO3 + maturin       | `pip install kailash-enterprise`           |
+| Ruby    | Magnus + rb-sys      | `gem install kailash`                      |
+| Node.js | napi-rs              | `npm install @kailash/core`                |
+| WASM    | wasm-bindgen         | `npm install @kailash/wasm`                |
+| Go      | CGo via kailash-capi | `go get github.com/kailash-sdk/kailash-go` |
+| Java    | JNI via kailash-capi | Maven `com.kailash:kailash-core`           |
 
-Both LocalRuntime and AsyncLocalRuntime inherit from BaseRuntime with shared capabilities:
-
-**BaseRuntime Foundation**:
-
-- 29 configuration parameters (debug, enable_cycles, conditional_execution, connection_validation, etc.)
-- Execution metadata management
-- Common initialization and validation modes (strict, warn, off)
-
-**Shared Mixins**:
-
-- **CycleExecutionMixin**: Cyclic workflow execution with validation
-- **ValidationMixin**: Workflow structure validation (5 methods)
-- **ConditionalExecutionMixin**: Conditional execution and branching with SwitchNode support
-
-**AsyncLocalRuntime-Specific**:
-
-- WorkflowAnalyzer for optimal execution strategy
-- Level-based parallelism for concurrent execution
-- Thread pool for sync nodes without blocking
-- Semaphore control to prevent resource exhaustion
-
-## Critical Rules
-
-- ✅ ALWAYS: `runtime.execute(workflow.build())`
-- ✅ String-based nodes: `workflow.add_node("NodeName", "id", {})`
-- ✅ 4-parameter connections: `(source_id, source_param, target_id, target_param)`
-- ✅ Docker/FastAPI: Use AsyncLocalRuntime (mandatory)
-- ✅ CLI/Scripts: Use LocalRuntime
-- ❌ NEVER: `workflow.execute(runtime)`
-- ❌ NEVER: Instance-based nodes
-- ❌ NEVER: Use LocalRuntime in Docker (causes hangs)
-
-## When to Use This Skill
-
-Use this skill when you need to:
-
-- Create custom workflows from scratch
-- Understand workflow fundamentals
-- Learn node patterns and connections
-- Set up runtime execution
-- Handle errors in workflows
-- Implement cyclic or async patterns
-- Integrate with MCP
-- Get started with Kailash SDK
-
-## Related Skills
-
-- **[02-dataflow](../02-dataflow/SKILL.md)** - Database operations framework built on Core SDK
-- **[03-nexus](../03-nexus/SKILL.md)** - Multi-channel platform framework built on Core SDK
-- **[04-kaizen](../04-kaizen/SKILL.md)** - AI agent framework built on Core SDK
-- **[06-cheatsheets](../06-cheatsheets/SKILL.md)** - Quick reference patterns
-- **[08-nodes-reference](../08-nodes-reference/SKILL.md)** - Complete node reference
-- **[09-workflow-patterns](../09-workflow-patterns/SKILL.md)** - Industry workflow templates
-- **[17-gold-standards](../17-gold-standards/SKILL.md)** - Mandatory best practices
-
-## Support
-
-For complex workflows or debugging, invoke:
-
-- `pattern-expert` - Workflow patterns and cyclic debugging
-- `testing-specialist` - Test workflow implementations
+C ABI (`kailash-capi`): Opaque pointers, JSON exchange, `cbindgen` header generation.

--- a/.claude/skills/04-kaizen/kaizen-agents-reasoning-history.md
+++ b/.claude/skills/04-kaizen/kaizen-agents-reasoning-history.md
@@ -163,6 +163,6 @@ Compaction is triggered when `needs_compaction()` returns `true`:
 
 ## Cross-References
 
-- EATP reasoning traces: [07-eatp-reference/](../07-eatp-reference/)
+- EATP reasoning traces: [26-eatp-reference/](../26-eatp-reference/)
 - Audit trail integration: [governance.md](governance.md) (AuditTrail `record_with_reasoning()`)
 - StructuredLlmClient (used by `compact_with_llm`): [structured-llm.md](structured-llm.md)

--- a/.claude/skills/05-enterprise/SKILL.md
+++ b/.claude/skills/05-enterprise/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: enterprise
+description: "Kailash Enterprise patterns for RBAC, ABAC, audit trails, multi-tenancy, SSO, compliance, and policy management. Use when asking about 'RBAC', 'ABAC', 'audit', 'multi-tenancy', 'SSO', 'enterprise security', 'access control', 'tenant isolation', or 'compliance reports'."
+---
+
+# Kailash Enterprise -- Quick Reference
+
+Enterprise-grade access control, audit, multi-tenancy, and compliance for the Kailash SDK. Crate: `kailash-enterprise`.
+
+## Key Modules
+
+| Module         | Purpose                        | Key Types                                                         | Skill File                 |
+| -------------- | ------------------------------ | ----------------------------------------------------------------- | -------------------------- |
+| **RBAC**       | Role-based access control      | `Role`, `Permission`, `RbacEngine`, hierarchical roles, wildcards | `enterprise-rbac.md`       |
+| **ABAC**       | Attribute-based access control | `Policy`, `Evaluator`, 16 operators, combined evaluation          | `enterprise-abac.md`       |
+| **Audit**      | Audit trail logging            | `AuditLog`, `AuditEntry`, tamper-evident, queryable               | `enterprise-audit.md`      |
+| **Tenancy**    | Multi-tenant isolation         | `TenantContext`, propagation, data isolation                      | `enterprise-tenancy.md`    |
+| **SSO**        | Single sign-on                 | SAML, OIDC integration patterns                                   | `enterprise-sso.md`        |
+| **Compliance** | Compliance reporting           | EATP/CARE report generators, human competency tracking            | `enterprise-compliance.md` |
+| **Policy**     | Policy management              | Policy engine, rule evaluation                                    | `enterprise-policy.md`     |
+| **Tokens**     | Token management               | JWT, session tokens, refresh flows                                | `enterprise-tokens.md`     |
+
+## Quick Patterns
+
+### RBAC Check
+
+```rust
+let engine = RbacEngine::new();
+engine.add_role("admin", &["read", "write", "delete"]);
+engine.add_role("viewer", &["read"]);
+engine.check("admin", "write")?; // Ok(true)
+```
+
+### ABAC Evaluation
+
+```rust
+let evaluator = AbacEvaluator::new();
+evaluator.add_policy(policy);
+let decision = evaluator.evaluate(&subject, &resource, &action, &environment)?;
+```
+
+### Audit Logging
+
+```rust
+let audit = AuditLog::new();
+audit.record(AuditEntry::new("user:123", "document:456", "read"));
+```
+
+### Multi-Tenancy
+
+```rust
+let ctx = TenantContext::new("tenant-1");
+// All operations within scope are tenant-isolated
+```
+
+## When to Use This Skill
+
+- Setting up role-based or attribute-based access control
+- Implementing audit trails for compliance
+- Adding multi-tenant data isolation
+- Configuring SSO (SAML/OIDC)
+- Generating compliance reports
+
+## Related
+
+- **enterprise-specialist** agent -- Framework-level architecture decisions
+- `skills/10-governance/` -- EATP/CARE governance patterns (trust enforcement)
+- `skills/29-pact/` -- PACT organizational governance (D/T/R addressing)
+- `enterprise-infra-bindings.md` -- Cross-language binding patterns for enterprise types

--- a/.claude/skills/06-cheatsheets/SKILL.md
+++ b/.claude/skills/06-cheatsheets/SKILL.md
@@ -10,6 +10,7 @@ Comprehensive collection of quick reference guides, common patterns, and best pr
 ## Overview
 
 This skill provides quick access to:
+
 - Common workflow patterns and anti-patterns
 - Node selection and usage guides
 - Production-ready patterns
@@ -20,6 +21,7 @@ This skill provides quick access to:
 ## Quick Reference Guides
 
 ### Essential Guides
+
 - **[kailash-quick-tips](kailash-quick-tips.md)** - Essential tips for Kailash development
 - **[common-mistakes-catalog](common-mistakes-catalog.md)** - Common pitfalls and solutions
 - **[node-selection-guide](node-selection-guide.md)** - Choosing the right nodes
@@ -27,6 +29,7 @@ This skill provides quick access to:
 - **[README](README.md)** - Cheatsheets overview
 
 ### Node References
+
 - **[admin-nodes-reference](admin-nodes-reference.md)** - Admin and management nodes
 - **[asyncsql-advanced](asyncsql-advanced.md)** - AsyncSQL node patterns
 - **[pythoncode-data-science](pythoncode-data-science.md)** - Data science with PythonCode
@@ -36,6 +39,7 @@ This skill provides quick access to:
 - **[query-routing](query-routing.md)** - Intelligent query routing
 
 ### Cyclic Workflow Patterns
+
 - **[cyclic-patterns-advanced](cyclic-patterns-advanced.md)** - Advanced cyclic patterns
 - **[cycle-aware-nodes](cycle-aware-nodes.md)** - Cycle-aware node development
 - **[cycle-debugging](cycle-debugging.md)** - Debugging cyclic workflows
@@ -45,6 +49,7 @@ This skill provides quick access to:
 - **[multi-path-cycles](multi-path-cycles.md)** - Multi-path cyclic patterns
 
 ### Production & Enterprise
+
 - **[production-patterns](production-patterns.md)** - Production-ready patterns
 - **[production-readiness](production-readiness.md)** - Production checklist
 - **[performance-optimization](performance-optimization.md)** - Performance tuning
@@ -54,6 +59,7 @@ This skill provides quick access to:
 - **[multi-tenancy-patterns](multi-tenancy-patterns.md)** - Multi-tenant architectures
 
 ### Enterprise Patterns
+
 - **[distributed-transactions](distributed-transactions.md)** - Distributed transaction patterns
 - **[saga-pattern](saga-pattern.md)** - Saga pattern for long transactions
 - **[enterprise-mcp](enterprise-mcp.md)** - Enterprise MCP patterns
@@ -61,6 +67,7 @@ This skill provides quick access to:
 - **[mcp-resource-subscriptions](mcp-resource-subscriptions.md)** - MCP resource patterns
 
 ### Development Tools
+
 - **[custom-node-guide](custom-node-guide.md)** - Creating custom nodes
 - **[developer-tools](developer-tools.md)** - Developer tooling
 - **[node-initialization](node-initialization.md)** - Node initialization patterns
@@ -69,18 +76,21 @@ This skill provides quick access to:
 - **[visualization](visualization.md)** - Workflow visualization
 
 ### Workflow Management
+
 - **[workflow-composition](workflow-composition.md)** - Composing complex workflows
 - **[workflow-design-process](workflow-design-process.md)** - Design process guide
 - **[workflow-api-deployment](workflow-api-deployment.md)** - Deploying workflows as APIs
 - **[workflow-export](workflow-export.md)** - Export and import patterns
 
 ### Integration Patterns
+
 - **[data-integration](data-integration.md)** - Data integration patterns
 - **[integration-mastery](integration-mastery.md)** - Advanced integration techniques
 
 ## Quick Patterns
 
 ### Basic Workflow
+
 ```python
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.runtime import LocalRuntime
@@ -92,6 +102,7 @@ results, run_id = runtime.execute(workflow.build())
 ```
 
 ### Common Node Selection
+
 ```python
 # Data processing
 workflow.add_node("PythonCode", "transform", {"code": "..."})
@@ -100,10 +111,11 @@ workflow.add_node("PythonCode", "transform", {"code": "..."})
 workflow.add_node("HTTPRequest", "api", {"url": "...", "method": "GET"})
 
 # AI/LLM
-workflow.add_node("LLMNode", "chat", {"model": "gpt-4", "prompt": "..."})
+workflow.add_node("LLMNode", "chat", {"model": os.environ["LLM_MODEL"], "prompt": "..."})
 ```
 
 ### Cyclic Pattern
+
 ```python
 workflow.add_node("LoopNode", "loop", {"max_iterations": 5})
 workflow.add_node("ProcessNode", "process", {})
@@ -113,16 +125,17 @@ workflow.add_connection("process", "output", "loop", "feedback")
 
 ## CRITICAL Gotchas
 
-| Rule | Why |
-|------|-----|
-| ❌ NEVER use raw SQL | Use DataFlow instead |
-| ✅ ALWAYS call `.build()` | Before `runtime.execute()` |
-| ❌ NEVER use relative imports | Use absolute imports |
-| ❌ NEVER mock in Tier 2-3 | Use real infrastructure |
+| Rule                          | Why                        |
+| ----------------------------- | -------------------------- |
+| ❌ NEVER use raw SQL          | Use DataFlow instead       |
+| ✅ ALWAYS call `.build()`     | Before `runtime.execute()` |
+| ❌ NEVER use relative imports | Use absolute imports       |
+| ❌ NEVER mock in Tier 2-3     | Use real infrastructure    |
 
 ## When to Use This Skill
 
 Use this skill when you need:
+
 - Quick reference for common patterns
 - Solution to a specific problem
 - Best practices for production
@@ -143,5 +156,6 @@ Use this skill when you need:
 ## Support
 
 For cheatsheet-related questions, invoke:
+
 - `pattern-expert` - Pattern selection and usage
 - ``decide-framework` skill` - Choose appropriate patterns for your use case

--- a/.claude/skills/06-python-bindings/SKILL.md
+++ b/.claude/skills/06-python-bindings/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: python-bindings
+description: "PyO3 Python binding patterns for Kailash Rust SDK. Use when asking about 'Python binding', 'PyO3', 'maturin', 'pip install kailash', 'Python wrapper', 'pyi stubs', 'Value mapping', or 'register_callback'."
+---
+
+# Python Bindings -- Quick Reference
+
+PyO3-based binding distributed as `pip install kailash-enterprise`. Import as `import kailash`.
+
+## Key Facts
+
+| Item              | Value                                     |
+| ----------------- | ----------------------------------------- |
+| **Package name**  | `kailash-enterprise` (PyPI)               |
+| **Import name**   | `import kailash`                          |
+| **Build tool**    | maturin (`maturin develop --release`)     |
+| **Rust crate**    | `bindings/kailash-python/`                |
+| **Python source** | `bindings/kailash-python/python/kailash/` |
+| **Stubs**         | `bindings/kailash-python/kailash.pyi`     |
+| **Native module** | `kailash._kailash` (compiled .so/.dylib)  |
+
+## Registered PyO3 Modules
+
+| Module                | Purpose        | Key Types                                                  |
+| --------------------- | -------------- | ---------------------------------------------------------- |
+| `kailash` (root)      | Core SDK       | `NodeRegistry`, `WorkflowBuilder`, `Runtime`, `Value`      |
+| `kailash.dataflow`    | Database       | `DataFlow`, `ModelDefinition`, `FilterCondition`           |
+| `kailash.enterprise`  | Access control | `RbacEngine`, `AbacEvaluator`, `AuditLog`, `TenantContext` |
+| `kailash.kaizen`      | AI agents      | `BaseAgent`, `LlmClient`, `AgentConfig`, `CostTracker`     |
+| `kailash.nexus`       | Deployment     | `NexusApp`, `NexusConfig`, `SessionStore`                  |
+| `kailash.trust_plane` | Trust          | `TrustProject`, `ConstraintEnvelope`                       |
+| `kailash.pact`        | Governance     | `Address`, `GovernanceEngine` (feature-gated)              |
+| `kailash.l3`          | L3 autonomy    | `L3Verdict`, `L3EnforcementPipeline` (feature-gated)       |
+
+## Value Mapping (Rust <-> Python)
+
+| Rust `Value`        | Python  |
+| ------------------- | ------- |
+| `Value::Null`       | `None`  |
+| `Value::Bool(b)`    | `bool`  |
+| `Value::Integer(i)` | `int`   |
+| `Value::Float(f)`   | `float` |
+| `Value::String(s)`  | `str`   |
+| `Value::Array(a)`   | `list`  |
+| `Value::Map(m)`     | `dict`  |
+
+## Quick Patterns
+
+### Build and install locally
+
+```bash
+cd bindings/kailash-python
+cargo clean -p kailash-python   # Prevent stale binary
+maturin develop --release
+```
+
+### Register a Python callback as a node
+
+```python
+import kailash
+reg = kailash.NodeRegistry()
+reg.register_callback("MyNode", my_func, ["input"], ["output"])
+```
+
+### v2 API (current)
+
+```python
+reg = kailash.NodeRegistry()
+builder = kailash.WorkflowBuilder()
+builder.add_node("NoOpNode", "n1", {})
+wf = builder.build(reg)
+rt = kailash.Runtime(reg)
+result = rt.execute(wf, {})
+```
+
+## Skill Files
+
+| File                           | Content                                     |
+| ------------------------------ | ------------------------------------------- |
+| `python-v2-quickstart.md`      | v2 API migration guide                      |
+| `python-cheatsheet.md`         | Common patterns                             |
+| `python-common-mistakes.md`    | Pitfalls and fixes                          |
+| `python-custom-nodes.md`       | Callback node patterns                      |
+| `python-framework-bindings.md` | DataFlow/Nexus/Kaizen/Enterprise Python API |
+| `python-gold-standards.md`     | Binding quality rules                       |
+| `python-migration-guide.md`    | v1 to v2 migration                          |
+| `python-available-nodes.md`    | Node list for Python                        |
+| `async-bridging.md`            | Async Rust <-> Python bridging              |
+
+## Related
+
+- **python-binding** agent -- PyO3 implementation specialist
+- **python-pattern-expert** agent -- Debugging PyO3 errors
+- `rules/release.md` -- Wheel build and PyPI publishing rules

--- a/.claude/skills/08-nodes-reference/SKILL.md
+++ b/.claude/skills/08-nodes-reference/SKILL.md
@@ -16,7 +16,7 @@ Comprehensive reference for all 110+ workflow nodes in Kailash SDK, organized by
 | Category          | File                                                          | Key Nodes                                                                            |
 | ----------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | AI & ML           | [nodes-ai-reference](nodes-ai-reference.md)                   | LLMNode, AnthropicNode, OpenAINode, VisionNode, AudioNode, EmbeddingNode, OllamaNode |
-| API & Integration | [nodes-api-reference](nodes-api-reference.md)                 | APICallNode, HTTPRequestNode, WebhookNode, GraphQLNode                               |
+| API & Integration | [nodes-api-reference](nodes-api-reference.md)                 | HTTPRequestNode, WebhookNode, GraphQLNode                                            |
 | Code Execution    | [nodes-code-reference](nodes-code-reference.md)               | PythonCodeNode, JavaScriptNode, BashNode                                             |
 | Data Processing   | [nodes-data-reference](nodes-data-reference.md)               | CSVReaderNode, JSONParserNode, DataValidatorNode, FilterNode, MapNode                |
 | Database          | [nodes-database-reference](nodes-database-reference.md)       | SQLQueryNode, AsyncSQLNode, DatabaseReadNode (+ DataFlow auto-generated)             |
@@ -34,7 +34,7 @@ Comprehensive reference for all 110+ workflow nodes in Kailash SDK, organized by
 | Text generation     | LLMNode, OpenAINode, AnthropicNode               |
 | Vision / Audio      | VisionNode, AudioNode                            |
 | Local LLMs          | OllamaNode                                       |
-| REST APIs           | APICallNode, HTTPRequestNode                     |
+| REST APIs           | HTTPRequestNode                                  |
 | Webhooks / GraphQL  | WebhookNode, GraphQLNode                         |
 | Custom Python logic | PythonCodeNode (most flexible)                   |
 | Database CRUD       | DataFlow auto-generated nodes (not raw DB nodes) |

--- a/.claude/skills/09-workflow-patterns/SKILL.md
+++ b/.claude/skills/09-workflow-patterns/SKILL.md
@@ -49,7 +49,7 @@ workflow.add_connection("transform", "output", "load", "data")
 ```python
 workflow.add_node("Embed", "embed", {"model": "text-embedding-ada-002"})
 workflow.add_node("Search", "search", {"index": "vectors"})
-workflow.add_node("Generate", "generate", {"model": "gpt-4"})
+workflow.add_node("Generate", "generate", {"model": os.environ["LLM_MODEL"]})
 ```
 
 ## Pattern Structure

--- a/.claude/skills/13-architecture-decisions/SKILL.md
+++ b/.claude/skills/13-architecture-decisions/SKILL.md
@@ -1,23 +1,72 @@
 ---
 name: architecture-decisions
-description: "Architecture decision guides for Kailash SDK including framework selection (Core SDK vs DataFlow vs Nexus vs Kaizen), runtime selection (Async vs Sync), database selection (PostgreSQL vs SQLite), node selection, and test tier selection. Use when asking about 'which framework', 'choose framework', 'which runtime', 'which database', 'which node', 'architecture decision', 'when to use', 'Core SDK vs DataFlow', 'PostgreSQL vs SQLite', 'AsyncLocalRuntime vs LocalRuntime', or 'test tier selection'."
+description: "Architecture decision guides for Kailash Rust SDK including framework selection (Core SDK vs DataFlow vs Nexus vs Kaizen), runtime selection (async execute vs sync execute_sync), database selection (PostgreSQL vs SQLite), node selection, and test tier selection. Use when asking about 'which framework', 'choose framework', 'which runtime', 'which database', 'which node', 'architecture decision', 'when to use', 'Core SDK vs DataFlow', 'PostgreSQL vs SQLite', 'async vs sync', or 'test tier selection'."
 ---
 
 # Kailash Architecture Decisions
 
-Decision guides for selecting the right frameworks, runtimes, databases, nodes, and testing strategies.
+Decision guides for selecting the right frameworks, runtimes, databases, nodes, and testing strategies for your Kailash Rust application.
+
+## Overview
+
+Comprehensive decision guides for:
+
+- Framework selection (Core SDK, DataFlow, Nexus, Kaizen)
+- Runtime selection (async `execute()` vs sync `execute_sync()`)
+- Database selection (PostgreSQL vs SQLite)
+- Node selection for specific tasks
+- Test tier selection (Unit, Integration, E2E)
 
 ## Reference Documentation
 
-| Decision  | File                                                                      | Quick Answer                                                                |
-| --------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Framework | [decide-framework](decide-framework.md)                                   | Core SDK (custom), DataFlow (DB), Nexus (multi-channel), Kaizen (AI agents) |
-| Runtime   | [decide-runtime](decide-runtime.md)                                       | Docker/FastAPI -> AsyncLocalRuntime; CLI/Scripts -> LocalRuntime            |
-| Database  | [decide-database-postgresql-sqlite](decide-database-postgresql-sqlite.md) | Production -> PostgreSQL; Dev/Test -> SQLite                                |
-| Node      | [decide-node-for-task](decide-node-for-task.md)                           | See node selection flow below                                               |
-| Test Tier | [decide-test-tier](decide-test-tier.md)                                   | Unit (fast), Integration (real infra), E2E (full system)                    |
+### Framework Selection
 
-## Framework Selection Matrix
+- **[decide-framework](decide-framework.md)** - Choose the right framework
+  - Core SDK: Custom workflows with full control
+  - DataFlow: Database-first applications
+  - Nexus: Multi-channel platforms
+  - Kaizen: AI agent systems
+  - When to use each
+  - Combining frameworks
+
+### Runtime Selection
+
+- **[decide-runtime](decide-runtime.md)** - Unified Runtime with async/sync execution
+  - Async: `runtime.execute(&workflow, inputs).await?`
+  - Sync: `runtime.execute_sync(&workflow, inputs)?`
+  - RuntimeConfig for tuning
+  - Level-based parallelism via tokio
+
+### Database Selection
+
+- **[decide-database-postgresql-sqlite](decide-database-postgresql-sqlite.md)** - PostgreSQL vs SQLite
+  - Production: PostgreSQL (sqlx::PgPool)
+  - Development/Testing: SQLite (sqlx::SqlitePool)
+  - Feature comparison
+  - sqlx compile-time query checking
+
+### Node Selection
+
+- **[decide-node-for-task](decide-node-for-task.md)** - Choose the right node
+  - AI tasks: LLMNode, EmbeddingNode
+  - API calls: HTTPRequestNode, GraphQLNode
+  - Custom logic: Use appropriate typed nodes
+  - Database: DataFlow auto-generated nodes
+  - File operations: FileReaderNode, CSVProcessorNode
+  - Conditional logic: SwitchNode
+
+### Test Tier Selection
+
+- **[decide-test-tier](decide-test-tier.md)** - Unit vs Integration vs E2E
+  - Tier 1: Unit tests (`#[test]`, `#[tokio::test]`)
+  - Tier 2: Integration tests (`#[cfg(feature = "integration")]`, real infrastructure)
+  - Tier 3: End-to-end tests (`#[cfg(feature = "e2e")]`, full system)
+  - When to use each tier
+  - Coverage targets
+
+## Key Decision Frameworks
+
+### Framework Selection Matrix
 
 | Need                  | Framework    | Why                       |
 | --------------------- | ------------ | ------------------------- |
@@ -27,74 +76,131 @@ Decision guides for selecting the right frameworks, runtimes, databases, nodes, 
 | **AI agents**         | Kaizen       | Signature-based agents    |
 | **All of above**      | Combine them | They work together        |
 
-## Runtime Selection Flow
+### Runtime Selection Flow
 
 ```
-Deploying to Docker/FastAPI/Kubernetes?
-  YES -> AsyncLocalRuntime (async-first, no threads)
-  NO  -> CLI/script?
-    YES -> LocalRuntime (sync execution)
-    NO  -> Use get_runtime() for auto-detection
+What execution context do you need?
+  |-- Async context (axum handler, tokio runtime)?
+  |     -> runtime.execute(&workflow, inputs).await?
+  |-- Sync context (CLI tool, script, test without async)?
+  |     -> runtime.execute_sync(&workflow, inputs)?
+  |-- Both?
+        -> Use the same Runtime instance; call whichever method fits
 ```
 
-## Database Selection Flow
+### Database Selection Flow
 
 ```
-Production deployment?     -> PostgreSQL (scalable, enterprise)
-Development/testing?       -> SQLite (simple, fast setup)
-High concurrency?          -> PostgreSQL (better concurrency)
+What's your use case?
+  |-- Production deployment?
+  |     -> PostgreSQL (sqlx::PgPool, scalable, enterprise)
+  |-- Development/testing?
+  |     -> SQLite (sqlx::SqlitePool, simple, fast setup)
+  |-- High concurrency?
+        -> PostgreSQL (better concurrency)
 ```
 
-## Node Selection Flow
+### Node Selection Flow
 
 ```
-Custom Python logic        -> PythonCodeNode
-LLM/AI tasks               -> LLMNode, OpenAINode, AnthropicNode
-Database operations        -> DataFlow auto-generated nodes
-HTTP API calls             -> APICallNode
-File reading               -> FileReaderNode
-Conditional routing        -> SwitchNode
-Not sure?                  -> Check nodes-quick-index
+What task are you doing?
+  |-- LLM/AI tasks -> LLMNode, EmbeddingNode, ClassificationNode
+  |-- Database operations -> DataFlow auto-generated nodes
+  |-- HTTP API calls -> HTTPRequestNode, GraphQLNode
+  |-- File reading -> FileReaderNode, CSVProcessorNode
+  |-- Conditional routing -> SwitchNode
+  |-- Not sure? -> Check CLAUDE.md node categories
 ```
 
-## Test Tier Flow
+### Test Tier Flow
 
 ```
-Individual function        -> Tier 1 (Unit)
-Workflow execution         -> Tier 2 (Integration, real infrastructure)
-Complete user flow         -> Tier 3 (E2E)
+What are you testing?
+  |-- Individual function -> Tier 1 (Unit, #[test])
+  |-- Workflow execution -> Tier 2 (Integration, cargo test --features integration)
+  |-- Complete user flow -> Tier 3 (E2E, cargo test --features e2e)
+  |-- All of above -> Use all tiers
 ```
 
 ## Critical Decision Rules
 
-### Framework
+### Framework Decisions
 
-- NEVER use ORM when DataFlow can generate nodes
+- Use Core SDK for custom workflows
+- Use DataFlow for database operations (not raw SQL or ORMs)
+- Use Nexus for multi-channel platforms (not raw axum directly)
+- Use Kaizen for AI agents (not building from scratch)
+- Combine frameworks as needed
+- NEVER use raw SQL when DataFlow can generate nodes
 - NEVER build API/CLI/MCP manually when Nexus can do it
+- NEVER skip framework evaluation
 
-### Runtime
+### Runtime Decisions
 
-- Docker/FastAPI -> AsyncLocalRuntime (mandatory)
-- NEVER use LocalRuntime in Docker (causes hangs)
-- NEVER mix runtimes in same application
+- One unified `Runtime` -- no separate sync/async types
+- Use `execute()` in async contexts (tokio, axum handlers)
+- Use `execute_sync()` in sync contexts (CLI, scripts)
+- RuntimeConfig for tuning (concurrency, debug, etc.)
 
-### Database
+### Database Decisions
 
-- Production -> PostgreSQL; NEVER SQLite for production high-concurrency
+- Production: PostgreSQL
+- Development: SQLite (for speed)
+- Testing: SQLite (for isolation)
+- Multi-instance: One DataFlow per database
+- NEVER use SQLite for production high-concurrency
 - NEVER skip connection pooling config
-- Multi-instance -> One DataFlow per database
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Choose between Core SDK, DataFlow, Nexus, or Kaizen
+- Decide between async `execute()` and sync `execute_sync()`
+- Decide between PostgreSQL and SQLite
+- Find the right node for a task
+- Determine test tier for a test case
+- Make architecture decisions
+- Understand trade-offs between options
+
+## Decision Templates
+
+### Starting a New Project
+
+```
+1. What's the primary use case?
+   - Database CRUD -> Start with DataFlow
+   - Multi-channel API -> Start with Nexus
+   - AI agents -> Start with Kaizen
+   - Custom workflows -> Start with Core SDK
+
+2. What's the execution context?
+   - Async (axum, tokio) -> runtime.execute().await?
+   - Sync (CLI, scripts) -> runtime.execute_sync()?
+
+3. What's the database?
+   - Production -> PostgreSQL
+   - Dev/Test -> SQLite
+
+4. How to test?
+   - Tier 1: Fast unit tests (#[test])
+   - Tier 2: Real infrastructure integration (#[cfg(feature = "integration")])
+   - Tier 3: Full system E2E (#[cfg(feature = "e2e")])
+```
 
 ## Related Skills
 
-- **[01-core-sdk](../../01-core-sdk/SKILL.md)** - Core SDK fundamentals
+- **[01-core](../../01-core/SKILL.md)** - Core SDK fundamentals
 - **[02-dataflow](../../02-dataflow/SKILL.md)** - DataFlow framework
 - **[03-nexus](../../03-nexus/SKILL.md)** - Nexus framework
 - **[04-kaizen](../../04-kaizen/SKILL.md)** - Kaizen framework
-- **[08-nodes-reference](../../08-nodes-reference/SKILL.md)** - Node reference
-- **[12-testing-strategies](../../12-testing-strategies/SKILL.md)** - Testing strategies
+- **[13-testing-strategies](../../13-testing-strategies/SKILL.md)** - Testing strategies
 
 ## Support
 
-- `decide-framework` skill - Framework selection and architecture
+For architecture decisions, invoke:
+
+- ``decide-framework` skill` - Framework selection and architecture
 - `analyst` - Deep analysis for complex decisions
-- `pattern-expert` - Pattern recommendations
+- `analyst` - Requirements breakdown
+- `rust-architect` - Cross-crate trait design and API patterns

--- a/.claude/skills/18-security-patterns/SKILL.md
+++ b/.claude/skills/18-security-patterns/SKILL.md
@@ -10,6 +10,7 @@ Mandatory security patterns for all Kailash SDK development. These patterns prev
 ## Overview
 
 Security patterns cover:
+
 - Secret management (no hardcoded credentials)
 - Input validation (prevent injection attacks)
 - Authentication and authorization
@@ -49,12 +50,12 @@ workflow.add_node("User_Read", "read_user", {
 
 ```python
 # ❌ WRONG - HTTP in production
-workflow.add_node("APICallNode", "api", {
+workflow.add_node("HTTPRequestNode", "api", {
     "url": "http://api.example.com/data"  # Insecure!
 })
 
 # ✅ CORRECT - HTTPS always
-workflow.add_node("APICallNode", "api", {
+workflow.add_node("HTTPRequestNode", "api", {
     "url": "https://api.example.com/data"
 })
 ```
@@ -62,22 +63,26 @@ workflow.add_node("APICallNode", "api", {
 ## Reference Documentation
 
 ### Core Security
+
 - **[security-secrets](security-secrets.md)** - Secret management patterns
 - **[security-input-validation](security-input-validation.md)** - Input validation
 - **[security-injection-prevention](security-injection-prevention.md)** - SQL/code injection prevention
 
 ### Authentication & Authorization
+
 - **[security-auth-patterns](security-auth-patterns.md)** - Auth best practices
 - **[security-api-keys](security-api-keys.md)** - API key management
 - **[security-tokens](security-tokens.md)** - Token handling
 
 ### OWASP Compliance
+
 - **[security-owasp-top10](security-owasp-top10.md)** - OWASP Top 10 prevention
 - **[security-audit-checklist](security-audit-checklist.md)** - Security audit checklist
 
 ## Security Checklist
 
 ### Before Every Commit
+
 - [ ] No hardcoded secrets (API keys, passwords, tokens)
 - [ ] All user inputs validated
 - [ ] SQL/code injection prevented
@@ -86,6 +91,7 @@ workflow.add_node("APICallNode", "api", {
 - [ ] Error messages don't expose internals
 
 ### Before Every Deployment
+
 - [ ] Environment variables configured
 - [ ] Secrets stored in secure vault
 - [ ] Authentication enabled
@@ -95,18 +101,19 @@ workflow.add_node("APICallNode", "api", {
 
 ## Common Vulnerabilities Prevented
 
-| Vulnerability | Prevention Pattern |
-|--------------|-------------------|
-| SQL Injection | Use DataFlow parameterized nodes |
-| Code Injection | Avoid `eval()`, use PythonCodeNode safely |
-| Credential Exposure | Environment variables, secret managers |
-| XSS | Output encoding, CSP headers |
-| CSRF | Token validation, SameSite cookies |
-| Insecure Deserialization | Validate serialized data |
+| Vulnerability            | Prevention Pattern                        |
+| ------------------------ | ----------------------------------------- |
+| SQL Injection            | Use DataFlow parameterized nodes          |
+| Code Injection           | Avoid `eval()`, use PythonCodeNode safely |
+| Credential Exposure      | Environment variables, secret managers    |
+| XSS                      | Output encoding, CSP headers              |
+| CSRF                     | Token validation, SameSite cookies        |
+| Insecure Deserialization | Validate serialized data                  |
 
 ## Integration with Rules
 
 Security patterns are enforced by:
+
 - `.claude/rules/security.md` - Security rules
 - `scripts/hooks/validate-bash-command.js` - Command validation
 - `gold-standards-validator` agent - Compliance checking
@@ -114,6 +121,7 @@ Security patterns are enforced by:
 ## When to Use This Skill
 
 Use this skill when:
+
 - Handling user input or external data
 - Storing or transmitting credentials
 - Making API calls to external services
@@ -130,6 +138,7 @@ Use this skill when:
 ## Support
 
 For security-related questions, invoke:
+
 - `security-reviewer` - OWASP-based security analysis
 - `gold-standards-validator` - Compliance checking
 - `testing-specialist` - Security testing patterns

--- a/.claude/skills/26-eatp-reference/trust-plane-skill.md
+++ b/.claude/skills/26-eatp-reference/trust-plane-skill.md
@@ -104,8 +104,8 @@ Five dimensions from EATP (see `docs/00-authority/05-trust-framework.md`):
 ## Related Skills
 
 - [10-governance](../10-governance/SKILL.md) — EATP/CARE governance via kailash-kaizen trust module
-- [07-eatp-reference](../07-eatp-reference/SKILL.md) — EATP protocol specification
-- [08-care-reference](../08-care-reference/SKILL.md) — CARE governance philosophy
+- [26-eatp-reference](../26-eatp-reference/SKILL.md) — EATP protocol specification
+- [27-care-reference](../27-care-reference/SKILL.md) — CARE governance philosophy
 
 ## Support
 

--- a/.claude/skills/28-ruby-bindings/SKILL.md
+++ b/.claude/skills/28-ruby-bindings/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ruby-bindings
+description: "Magnus Ruby binding patterns for Kailash Rust SDK. Use when asking about 'Ruby binding', 'Magnus', 'rb-sys', 'gem kailash', 'Ruby wrapper', 'GVL release', or 'block-based lifecycle'."
+---
+
+# Ruby Bindings -- Quick Reference
+
+Magnus-based binding distributed as `kailash` gem. Uses block-based resource lifecycle with GVL release for concurrent execution.
+
+## Key Facts
+
+| Item              | Value                                   |
+| ----------------- | --------------------------------------- |
+| **Gem name**      | `kailash`                               |
+| **Require**       | `require 'kailash'`                     |
+| **Rust crate**    | `bindings/kailash-ruby/`                |
+| **FFI framework** | Magnus 0.8 / rb-sys 0.9                 |
+| **Library type**  | cdylib (.bundle on macOS, .so on Linux) |
+
+## Block-Based Lifecycle
+
+Ruby binding uses block-based resource management (no manual close):
+
+```ruby
+require 'kailash'
+
+Kailash::Registry.open do |reg|
+  builder = Kailash::WorkflowBuilder.new
+  builder.add_node("NoOpNode", "n1", {})
+  wf = builder.build(reg)
+
+  Kailash::Runtime.open(reg) do |rt|
+    result = rt.execute(wf, {})
+    puts result.results
+  end
+end
+```
+
+## GVL Strategy
+
+- Workflow executor runs **without** the GVL (`without_gvl`)
+- Callback nodes reacquire the GVL (`with_gvl`) to call Ruby blocks
+- This allows concurrent workflow execution alongside Ruby threads
+
+## Registered Modules
+
+| Module                     | Key Classes                        |
+| -------------------------- | ---------------------------------- |
+| `Kailash::Registry`        | Node registry with `open` block    |
+| `Kailash::WorkflowBuilder` | DAG builder                        |
+| `Kailash::Runtime`         | Execution engine with `open` block |
+| `Kailash::Value`           | Value mapping (Rust <-> Ruby)      |
+
+## Skill Files
+
+| File                         | Content                |
+| ---------------------------- | ---------------------- |
+| `ruby-quickstart.md`         | Getting started guide  |
+| `ruby-cheatsheet.md`         | Common patterns        |
+| `ruby-common-mistakes.md`    | Pitfalls and fixes     |
+| `ruby-custom-nodes.md`       | Callback node patterns |
+| `ruby-framework-bindings.md` | Framework Ruby API     |
+| `ruby-gold-standards.md`     | Binding quality rules  |
+| `ruby-available-nodes.md`    | Node list for Ruby     |
+
+## Related
+
+- **ruby-binding** agent -- Magnus implementation specialist
+- **ruby-pattern-expert** agent -- Debugging Magnus errors
+- **ruby-gold-standards** agent -- Ruby binding compliance validation

--- a/.claude/skills/32-kaizen-agents/reasoning-and-history.md
+++ b/.claude/skills/32-kaizen-agents/reasoning-and-history.md
@@ -163,6 +163,6 @@ Compaction is triggered when `needs_compaction()` returns `true`:
 
 ## Cross-References
 
-- EATP reasoning traces: [07-eatp-reference/](../07-eatp-reference/)
+- EATP reasoning traces: [26-eatp-reference/](../26-eatp-reference/)
 - Audit trail integration: [governance.md](governance.md) (AuditTrail `record_with_reasoning()`)
 - StructuredLlmClient (used by `compact_with_llm`): [structured-llm.md](structured-llm.md)


### PR DESCRIPTION
## Summary
- Fix 4 stale cross-refs (07-eatp→26-eatp, 08-care→27-care)
- 3 new SKILL.md progressive disclosure indexes (05-enterprise, 06-python-bindings, 28-ruby-bindings)
- Global phantom node fixes propagated

🤖 Generated with [Claude Code](https://claude.com/claude-code)