### PR TITLE
fix(audit): cc-audit fixes — delegation routing + descriptions

### DIFF
--- a/.claude/agents/frameworks/mcp-specialist.md
+++ b/.claude/agents/frameworks/mcp-specialist.md
@@ -29,6 +29,8 @@ For common MCP queries, use Skills for instant answers:
 4. **Service Discovery** - Registry integration patterns
 5. **Breaking Changes** - Migration strategies for v0.6.6+
 
+**Hand off to `mcp-platform-specialist`** for: FastMCP platform server, contributor plugins, security tiers (T1-T4), `platform_map()` debugging, stdio/SSE transport config. This agent covers general MCP protocol; the platform specialist covers the Kailash-specific platform server.
+
 ## Responsibilities
 
 1. Guide production-ready MCP server creation with auth and monitoring

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -8,9 +8,12 @@ When working with Kailash frameworks, MUST consult the relevant specialist:
 - **nexus-specialist**: API or deployment work
 - **kaizen-specialist**: AI agent work
 - **mcp-specialist**: MCP integration work
+- **mcp-platform-specialist**: FastMCP platform server, contributor plugins, security tiers
 - **pact-specialist**: Organizational governance work
+- **ml-specialist**: ML lifecycle, feature stores, training, drift monitoring, AutoML
+- **align-specialist**: LLM fine-tuning, LoRA adapters, alignment methods, model serving
 
-**Applies when**: Creating workflows, modifying DB models, setting up endpoints, building agents, implementing governance.
+**Applies when**: Creating workflows, modifying DB models, setting up endpoints, building agents, implementing governance, training ML models, fine-tuning LLMs, configuring MCP platform server.
 
 **Why:** Framework specialists encode hard-won patterns and constraints that generalist agents miss, leading to subtle misuse of DataFlow, Nexus, or Kaizen APIs.
 

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -1,0 +1,88 @@
+---
+paths:
+  - "pyproject.toml"
+  - "Cargo.toml"
+  - "package.json"
+---
+
+# Dependency Rules
+
+## Latest Versions Always
+
+All dependencies MUST use the latest stable version. Do not pin to old versions out of caution.
+
+**Why:** Defensive pinning creates a maintenance treadmill where every update requires manual cap-bumping, and the project silently falls behind on security patches, performance improvements, and API fixes.
+
+```toml
+# ✅ Uncapped or wide range
+pydantic = ">=2.0"
+polars = ">=1.0"
+
+# ❌ Defensive caps
+pydantic = ">=2.0,<3.0"
+polars = ">=1.0,<1.5"
+```
+
+## No Caps on Transitive Dependencies
+
+Do NOT add version constraints for packages your code does not directly import. If a package is only a transitive dependency (required by one of your direct dependencies), let the upstream package manage compatibility.
+
+**Why:** Capping a transitive dependency you don't import is purely speculative — you have no code that could break. The upstream package already declares its own compatibility range. Your cap just blocks users from getting updates and creates resolution conflicts.
+
+```toml
+# ❌ datasets is used by trl and transformers, not by us
+dependencies = ["trl>=0.12", "datasets>=3.0,<4.0"]
+
+# ✅ Only constrain what you import
+dependencies = ["trl>=0.12"]
+```
+
+**Test:** `grep -r "import datasets" src/` returns zero? Then `datasets` is not your dependency — remove it from `pyproject.toml`.
+
+## Own the Stack — Replace or Re-Implement
+
+If a dependency is unmaintained (no release in 12+ months, unresolved critical issues, archived repo) or constrains your architecture, re-implement it with full API parity. Do not work around a broken or stale package — own the code.
+
+This applies equally to small utilities and large frameworks. If the reference package does X, your replacement MUST do X with identical behavior at the API surface.
+
+**Why:** Unmaintained packages accumulate CVEs, break with new Python/Rust versions, and force the entire ecosystem to work around their bugs. Owning the implementation eliminates the external risk and gives you full control over the API surface, performance, and release cadence.
+
+Process:
+
+1. Identify the full API surface of the reference package that you (or your users) depend on
+2. Re-implement with full parity — every public function, class, and behavior
+3. Test against the reference package's own test suite where available
+4. Provide a drop-in migration path (same import names or thin adapter)
+5. Remove the old dependency
+
+## Minimum Version Floors Are Fine
+
+Lower bounds (`>=X.Y`) are appropriate when your code uses features introduced in that version.
+
+**Why:** A floor prevents users from hitting cryptic errors when they install an old version missing the API you call.
+
+```toml
+# ✅ We use pydantic v2 model_validator
+pydantic = ">=2.0"
+
+# ✅ We use polars LazyFrame.collect_async (added in 0.20)
+polars = ">=0.20"
+```
+
+## MUST NOT
+
+- Cap a dependency you do not directly import
+
+**Why:** You cannot know when a transitive dependency will break your code because you have no code that uses it. The cap just blocks upgrades.
+
+- Pin exact versions in library pyproject.toml (`==X.Y.Z`)
+
+**Why:** Exact pins in libraries create resolution conflicts for every downstream user who has a different pin.
+
+- Keep unmaintained dependencies — re-implement instead
+
+**Why:** Every unmaintained dependency is a ticking time bomb that will eventually block a Python/Rust version upgrade or introduce a security vulnerability. If you can build it, own it.
+
+- Work around a broken dependency instead of replacing it
+
+**Why:** Workarounds create parallel implementations that diverge from the reference API, doubling maintenance cost and surprising users with behavior differences.

--- a/.claude/skills/05-kailash-mcp/SKILL.md
+++ b/.claude/skills/05-kailash-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kailash-mcp
-description: "Kailash MCP (Model Context Protocol) - production-ready MCP server implementation for AI agent integration. Use when asking about 'MCP', 'Model Context Protocol', 'MCP server', 'MCP client', 'MCP tools', 'MCP resources', 'MCP prompts', 'MCP authentication', 'MCP transports', 'stdio transport', 'SSE transport', 'HTTP transport', 'MCP testing', 'progress reporting', or 'structured tools'."
+description: "Kailash MCP — production-ready MCP server, platform server, tools, resources, transports. Use for MCP integration, platform config, security tiers."
 ---
 
 # Kailash MCP - Model Context Protocol Integration
@@ -206,6 +206,6 @@ def analyze_tool(text: str) -> str:
 
 For MCP-specific questions, invoke:
 
-- `mcp-specialist` - MCP server implementation
+- `mcp-platform-specialist` - Platform server, contributor plugins, security tiers, platform_map
+- `mcp-specialist` - General MCP protocol, custom servers, auth, transports
 - `testing-specialist` - MCP testing strategies
-- ``decide-framework` skill` - MCP integration architecture

--- a/.claude/skills/05-kailash-mcp/mcp-contributor-pattern.md
+++ b/.claude/skills/05-kailash-mcp/mcp-contributor-pattern.md
@@ -347,7 +347,7 @@ async def test_full_server_starts_with_contributor():
 
 ## When to Escalate to Subagent
 
-Use `mcp-specialist` when:
+Use `mcp-platform-specialist` when:
 
 - Implementing cross-framework scanning in `platform_map`
 - Adding Tier 4 execution tools with subprocess isolation

--- a/.claude/skills/05-kailash-mcp/mcp-platform-map.md
+++ b/.claude/skills/05-kailash-mcp/mcp-platform-map.md
@@ -345,7 +345,7 @@ Resources provide the same data but through the MCP resource protocol. Useful fo
 
 ## When to Escalate to Subagent
 
-Use `mcp-specialist` when:
+Use `mcp-platform-specialist` when:
 
 - Detection heuristics are missing artifacts that should be found
 - Implementing custom connection detection logic

--- a/.claude/skills/05-kailash-mcp/mcp-platform-overview.md
+++ b/.claude/skills/05-kailash-mcp/mcp-platform-overview.md
@@ -166,7 +166,7 @@ Connections are detected via deterministic naming conventions (e.g., a handler r
 
 ## When to Escalate to Subagent
 
-Use `mcp-specialist` when:
+Use `mcp-platform-specialist` when:
 
 - Troubleshooting contributor registration failures
 - Implementing custom transport configurations

--- a/.claude/skills/05-kailash-mcp/mcp-security-tiers.md
+++ b/.claude/skills/05-kailash-mcp/mcp-security-tiers.md
@@ -216,7 +216,7 @@ KAILASH_MCP_ENABLE_VALIDATION=false kailash-mcp --project-root .
 
 ## When to Escalate to Subagent
 
-Use `mcp-specialist` when:
+Use `mcp-platform-specialist` when:
 
 - Designing custom tier boundaries for a new contributor
 - Implementing subprocess isolation for Tier 4 tools

--- a/.claude/skills/34-kailash-ml/SKILL.md
+++ b/.claude/skills/34-kailash-ml/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kailash-ml
-description: "Kailash ML - classical and deep learning lifecycle framework with polars-native engines, agent-augmented AutoML, and ONNX cross-language serving. Use when asking about 'feature store', 'model registry', 'training pipeline', 'inference server', 'drift monitoring', 'AutoML', 'hyperparameter search', 'ensemble', 'ONNX export', 'ML agents', 'RL training', 'feature engineering', 'model lifecycle', 'experiment tracking', 'ML guardrails', 'model serving', 'batch inference', or 'drift detection'."
+description: "Kailash ML — classical + deep learning lifecycle with polars-native engines, AutoML, ONNX serving. Use for feature stores, model training, drift monitoring, inference."
 ---
 
 # Kailash ML - Classical & Deep Learning Lifecycle

--- a/.claude/skills/35-kailash-align/SKILL.md
+++ b/.claude/skills/35-kailash-align/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kailash-align
-description: "Kailash Align - LLM fine-tuning and alignment framework with 12 supported methods across 4 categories (offline, unpaired, monolithic, online). Use when asking about 'fine-tuning', 'alignment', 'DPO', 'RLHF', 'GRPO', 'LoRA', 'QLoRA', 'SFT', 'adapter registry', 'model serving', 'GGUF export', 'Ollama deployment', 'vLLM', 'reward functions', 'KaizenModelBridge', 'alignment evaluation', 'win-rate', 'adapter chaining', or 'LLM training'."
+description: "Kailash Align — LLM fine-tuning/alignment with 12 methods (DPO, RLHF, LoRA, GRPO). Use for fine-tuning, adapter management, eval, model serving."
 ---
 
 # Kailash Align - LLM Fine-Tuning & Alignment


### PR DESCRIPTION
## Summary
- agents.md: add ml, align, mcp-platform specialists to delegation table (CRITICAL — without this, no downstream repo delegates to these agents)
- 3 SKILL.md descriptions trimmed from 400-500 to ~140 chars (token savings)
- MCP platform sub-file escalation routing fixed to mcp-platform-specialist
- mcp-specialist: handoff note for platform-specific questions
- dependencies.md: new rule (latest versions, no transitive caps, own the stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)