### PR TITLE
chore(sync): bump VERSION 1.6.0 — TSG specialists + loom 1.6.0

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,16 +1,30 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "coc-use-template",
   "description": "COC USE template for Rust SDK projects",
-  "released": "2026-04-04",
+  "released": "2026-04-05",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "1.4.0",
+    "version": "1.6.0",
     "build_version": "3.8.0",
-    "synced_at": "2026-04-04T08:00:00Z"
+    "synced_at": "2026-04-05T10:00:00Z"
   },
   "changelog": [
+    {
+      "version": "1.6.0",
+      "date": "2026-04-05",
+      "summary": "TSG specialists + stale agent cleanup + dependency rules + VERSION alignment",
+      "changes": [
+        "NEW: 3 specialist agents (mcp-platform, ml, align) from loom v1.6.0",
+        "NEW: skills/34-kailash-ml/ (8 ML lifecycle skills)",
+        "NEW: skills/35-kailash-align/ (5 LLM alignment skills)",
+        "NEW: 7 MCP platform skills in skills/05-kailash-mcp/",
+        "UPDATED: rules/agents.md — delegation table expanded to 8 specialists",
+        "UPDATED: commands/wrapup.md — red team verification with inline evidence",
+        "FIXED: cc-audit fixes — delegation routing, SKILL.md descriptions, BUILD path contamination"
+      ]
+    },
     {
       "version": "1.5.0",
       "date": "2026-04-04",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,10 @@ Phase commands replace the manual copy-paste workflow. Each loads the correspond
 - **nexus-specialist** — Multi-channel platform (API/CLI/MCP)
 - **kaizen-specialist** — AI agents, signatures, multi-agent coordination
 - **mcp-specialist** — MCP server implementation
+- **mcp-platform-specialist** — FastMCP platform server, contributor plugins, security tiers
 - **pact-specialist** — Organizational governance (D/T/R, envelopes, clearance)
+- **ml-specialist** — ML lifecycle, feature stores, training, drift monitoring
+- **align-specialist** — LLM fine-tuning, LoRA adapters, alignment, model serving
 
 ### Implementation (`agents/implementation/`)
 


### PR DESCRIPTION
## Summary
- VERSION 1.5.0 → 1.6.0, upstream loom 1.4.0 → 1.6.0
- CLAUDE.md: added mcp-platform, ml, align specialists to Framework Specialists section
- Artifacts (agents, skills) already distributed in prior PRs — this aligns VERSION tracking

## Test plan
- [ ] Verify VERSION JSON is valid
- [ ] Verify CLAUDE.md agent list matches actual agents/ directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)