### PR TITLE
chore(sync): SDK pin — kailash-enterprise 3.6.4→3.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     # Kailash Enterprise (Rust-backed, all-in-one: Core SDK + DataFlow + Nexus + Kaizen + Enterprise)
-    "kailash-enterprise>=3.6.4",
+    "kailash-enterprise>=3.9.0",
     # CLI Framework
     "click>=8.0",
     "rich>=13.0.0",


### PR DESCRIPTION
## Summary
Bump kailash-enterprise pin to match kailash-rs v3.9.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)