### PR TITLE
feat(sync): GitHub fallback for downstream /sync

### DIFF
--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -21,7 +21,7 @@ This is a **merge**, not an overwrite. Three categories of files:
 
 | Category             | Examples                                        | Behavior                      |
 | -------------------- | ----------------------------------------------- | ----------------------------- |
-| **Shared artifacts** | agents/analyst.md, rules/security.md       | **Updated** from template     |
+| **Shared artifacts** | agents/analyst.md, rules/security.md            | **Updated** from template     |
 | **Project-specific** | agents/project/_, skills/project/_, workspaces/ | **Preserved** — never touched |
 | **Per-repo data**    | learning/\*, learned-instincts.md, .proposals/  | **Preserved** — never touched |
 
@@ -43,19 +43,26 @@ Search paths (in order):
 
 1. `../{template}/` (sibling directory)
 2. `../../loom/{template}/` (loom parent)
-3. Ask user for path
+3. **GitHub fetch** — if not found locally, shallow-clone from GitHub:
+   ```bash
+   git clone --depth 1 https://github.com/terrene-foundation/kailash-coc-claude-rs.git /tmp/kailash-coc-template
+   ```
+   Use `/tmp/kailash-coc-template` as the template path. Clean up after sync with `rm -rf /tmp/kailash-coc-template`.
+4. Ask user for path (last resort)
 
 ### 3. Check SDK version compatibility
 
 Read this project's SDK version from `pyproject.toml` (look for `kailash-enterprise`) or `Gemfile` (look for `kailash` gem) or `Cargo.toml` (look for `kailash` dependency). Read the template's VERSION file for the `build_version`.
 
 Report both in the sync header:
+
 ```
 Project SDK: kailash-enterprise==1.0.0 (from pyproject.toml)
 Template COC: 1.0.0 (from template .claude/VERSION)
 ```
 
 If the template artifacts were codified from a newer SDK version than the project uses, warn:
+
 ```
 ⚠ Template artifacts may reference SDK features newer than your installed version.
   Consider upgrading your SDK dependency.


### PR DESCRIPTION
When template not found locally, /sync shallow-clones from GitHub.