### PR TITLE
revert(rules): restore paths frontmatter on 9 files (2.3.1 was wrong)

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,20 +1,37 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.2",
   "type": "coc-use-template",
   "description": "COC USE template for Rust SDK projects",
   "released": "2026-04-08",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "build_version": "3.12.0",
     "synced_at": "2026-04-08T00:00:00Z"
   },
   "changelog": [
     {
+      "version": "2.3.2",
+      "date": "2026-04-08",
+      "summary": "REVERT 2.3.1: restore `paths:` frontmatter on 9 rule files (5 global + 4 rs variant). Previous diagnosis was wrong — Claude Code path-scoped rules load ONCE on first matching read and stay sticky, NOT per tool call. Stripping `paths:` moved rules into the always-on baseline (~5500 tokens per stripped large rule), increasing session cost. Verified empirically via subprocess tests + Claude Code official docs (`code.claude.com/docs/en/memory`: 'Path-scoped rules trigger when Claude reads files matching the pattern, not on every tool use').",
+      "changes": [
+        "RESTORED (global): rules/agent-reasoning.md — paths: **/kaizen/**, **/*agent*, **/agents/**",
+        "RESTORED (global): rules/artifact-flow.md — paths: .claude/**, sync-manifest.yaml, **/VERSION, *.md",
+        "RESTORED (global): rules/env-models.md — paths: **/*.py, **/*.ts, **/*.js, .env*",
+        "RESTORED (global): rules/python-environment.md — paths: **/*.py, pyproject.toml, conftest.py, tests/**",
+        "RESTORED (global): rules/terrene-naming.md — paths: **/*.md, **/README*, **/LICENSE*, **/CLAUDE.md",
+        "RESTORED (rs variant): rules/build-speed.md — paths: **/*.rs, **/*.toml, **/Cargo.lock",
+        "RESTORED (rs variant): rules/framework-first.md — paths: **/*.rs",
+        "RESTORED (rs variant): rules/patterns.md — paths: **/*.py, **/*.ts, **/*.js",
+        "RESTORED (rs variant): rules/testing.md — paths: tests/**, **/*test*, **/*spec*, conftest.py",
+        "NOTE: Wide patterns are restored as-is (per user direction). Narrowing is a separate refinement task."
+      ]
+    },
+    {
       "version": "2.3.1",
       "date": "2026-04-08",
-      "summary": "fix(rules): strip broad path matchers causing per-read context bloat — rules now load once in system prompt instead of re-injecting on every matching tool call",
+      "summary": "[REVERTED in 2.3.2] fix(rules): strip broad path matchers — based on incorrect diagnosis. See 2.3.2 for evidence and revert.",
       "changes": [
         "UPDATED: rules/patterns.md, env-models.md, framework-first.md, python-environment.md, terrene-naming.md, artifact-flow.md, agent-reasoning.md, testing.md, build-speed.md — removed broad `paths:` frontmatter",
         "NEW: rules/build-speed.md — was missing from template (rs variant addition), now synced",

--- a/.claude/rules/agent-reasoning.md
+++ b/.claude/rules/agent-reasoning.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/kaizen/**"
+  - "**/*agent*"
+  - "**/agents/**"
+---
+
 # Agent Reasoning Architecture — LLM-First Rule
 
 ## Scope

--- a/.claude/rules/artifact-flow.md
+++ b/.claude/rules/artifact-flow.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - ".claude/**"
+  - "sync-manifest.yaml"
+  - "**/VERSION"
+  - "*.md"
+---
+
 # Artifact Flow Rules
 
 ## Authority Chain

--- a/.claude/rules/build-speed.md
+++ b/.claude/rules/build-speed.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.rs"
+  - "**/*.toml"
+  - "**/Cargo.lock"
+---
+
 # Build Speed Rules
 
 ## MUST: Targeted Builds, Never Workspace-Wide

--- a/.claude/rules/env-models.md
+++ b/.claude/rules/env-models.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+  - ".env*"
+---
+
 # Environment Variables & Model Rules
 
 ## .env Is The Single Source of Truth

--- a/.claude/rules/framework-first.md
+++ b/.claude/rules/framework-first.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.rs"
+---
+
 # Framework-First: Use the Highest Abstraction Layer
 
 Default to Engines. Drop to Primitives only when Engines can't express the behavior. Never use Raw.

--- a/.claude/rules/patterns.md
+++ b/.claude/rules/patterns.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+---
+
 # Kailash Pattern Rules (Rust SDK + Python Bindings)
 
 ### 1. Runtime Execution Pattern

--- a/.claude/rules/python-environment.md
+++ b/.claude/rules/python-environment.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.py"
+  - "pyproject.toml"
+  - "conftest.py"
+  - "tests/**"
+---
+
 # Python Environment Rules
 
 Every Python project MUST use `.venv` at the project root, managed by `uv`. Global Python is BLOCKED.

--- a/.claude/rules/terrene-naming.md
+++ b/.claude/rules/terrene-naming.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.md"
+  - "**/README*"
+  - "**/LICENSE*"
+  - "**/CLAUDE.md"
+---
+
 # Terrene Foundation Naming
 
 ## Rules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "tests/**"
+  - "**/*test*"
+  - "**/*spec*"
+  - "conftest.py"
+---
+
 # Testing Rules (Rust SDK + Python Bindings)
 
 ## Test-Once Protocol


### PR DESCRIPTION
## Summary

Reverts the `paths:` frontmatter strip from 2.3.1. That strip was based on an incorrect diagnosis: I believed path-scoped rules re-injected on every matching tool call. They do not.

**Actual Claude Code behavior** (verified empirically + docs):
- Rules WITHOUT `paths:` → loaded at session start, always-on
- Rules WITH `paths:` → load **once** on first matching tool call, then sticky
- Claude Code docs: *"Path-scoped rules trigger when Claude reads files matching the pattern, not on every tool use."*

**Effect of the bad strip**: moved 9 rules (5 globals + 4 rs variants) into the always-on baseline, adding ~5500 tokens per stripped large rule per session start.

**This PR**: restores wide `paths:` patterns. Bumps VERSION 2.3.1 → 2.3.2.

Synced from loom 2.5.2 (revert).

## Test plan
- [x] All 9 rule files have YAML frontmatter restored
- [x] VERSION bumped to 2.3.2
- [x] Changelog 2.3.1 marked [REVERTED]

🤖 Generated with [Claude Code](https://claude.com/claude-code)