### PR TITLE
chore: sync loom 2.8.1 — arbor rules + USE path fix

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "coc-use-template",
   "description": "COC USE template for Python/Ruby developers using Rust-backed Kailash bindings",
   "released": "2026-04-11",
@@ -8,9 +8,18 @@
     "type": "coc-source",
     "version": "2.8.0",
     "build_version": "3.12.0",
-    "synced_at": "2026-04-11T14:00:00+08:00"
+    "synced_at": "2026-04-11T18:00:00+08:00"
   },
   "changelog": [
+    {
+      "version": "2.5.1",
+      "date": "2026-04-11",
+      "summary": "Sync loom \u2014 Python hygiene rules from kailash-py arbor session. Applies to rs template because Python/Ruby devs consuming Rust bindings hit the same pyenv shim and monorepo editable-install traps. No rs-specific variant overlay.",
+      "changes": [
+        "MODIFIED: rules/python-environment.md \u2014 MUST Rule 1: bare python/python3/pytest BLOCKED, must use .venv/bin/python or uv run (pyenv shim trap rediscovered in kailash-py arbor session). MUST Rule 2: monorepo packages/*/pyproject.toml must be editable-installed, PYTHONPATH workaround BLOCKED.",
+        "MODIFIED: rules/infrastructure-sql.md \u2014 \u00a78 rewritten as MUST: adapter classes wrapping optional drivers must import driver inside connect(), top-level import BLOCKED. Added \u00a78a: regression test for lazy-import required. Applies to any Python adapter in downstream projects built on Rust bindings."
+      ]
+    },
     {
       "version": "2.5.0",
       "date": "2026-04-11",

--- a/.claude/rules/infrastructure-sql.md
+++ b/.claude/rules/infrastructure-sql.md
@@ -104,11 +104,53 @@ self._store: dict = {}  # Grows without bound -> OOM
 
 Default bound: 10,000 entries.
 
-### 8. Lazy Driver Imports
+### 8. Adapter Classes MUST Import Drivers Lazily
 
-`aiosqlite`, `asyncpg`, `aiomysql` are in base `pip install kailash`. Lazy imports remain acceptable for consistency.
+Every adapter class wrapping an optional backend driver (`motor`, `pymongo`, `aiomysql`, `asyncpg`, `aiosqlite`, `aiokafka`, `redis.asyncio`, etc.) MUST import the driver **inside** `connect()` / `__aenter__` and raise a descriptive `ImportError` at the call site if missing. Top-level `from <driver> import ...` on the adapter module is BLOCKED.
 
-**Why:** Eager driver imports force installation of all database drivers even when only one backend is used, bloating dependency footprint for single-database deployments.
+```python
+# DO
+class MongoDBAdapter(BaseAdapter):
+    async def connect(self) -> None:
+        try:
+            from motor.motor_asyncio import AsyncIOMotorClient
+        except ImportError as exc:
+            raise ImportError(
+                "MongoDB support requires motor. pip install motor pymongo"
+            ) from exc
+        self._client = AsyncIOMotorClient(self._url)
+
+# DO NOT — top-level import kills every consumer
+from motor.motor_asyncio import AsyncIOMotorClient  # breaks `from dataflow import DataFlow`
+```
+
+**BLOCKED rationalizations:** "motor is in our main deps anyway"; "the driver is small"; "users who don't want MongoDB will install kailash[sql-only]".
+
+**Why:** A top-level `from motor...` executes on `from dataflow import DataFlow` even for PostgreSQL-only projects. When the driver is absent the package fails to import at all — users see cryptic errors from modules they never intended to use. Lazy imports turn that into actionable errors at `connect()` time.
+
+### 8a. Lazy-Import Regression Test Required
+
+Every lazy-driver adapter MUST have a regression test that asserts the top-level package import succeeds with the driver absent. Static grep alone is BLOCKED — a future "tidy up imports" refactor silently reintroduces the bug.
+
+```python
+# DO
+def test_dataflow_importable_without_motor(monkeypatch):
+    import sys
+    class _Block:
+        def find_module(self, name, path=None):
+            return self if name.startswith("motor") else None
+        def load_module(self, name):
+            raise ImportError(f"simulated: {name} not installed")
+    monkeypatch.setattr(sys, "meta_path", [_Block(), *sys.meta_path])
+    for mod in [m for m in sys.modules if m.startswith(("dataflow", "motor"))]:
+        sys.modules.pop(mod, None)
+    from dataflow import DataFlow
+    assert DataFlow is not None
+```
+
+**Why:** Without a behavioral test the pattern is only human-enforced. The MongoDB adapter regression that motivated this rule had passed code review — the lazy pattern only surfaced when a downstream Docker build died on missing motor.
+
+Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-11) — `packages/kailash-dataflow/src/dataflow/adapters/mongodb.py` imported `motor.motor_asyncio` at module top, breaking `from dataflow import DataFlow` for every non-MongoDB project.
 
 ## MUST NOT
 

--- a/.claude/rules/python-environment.md
+++ b/.claude/rules/python-environment.md
@@ -41,8 +41,79 @@ uv run python scripts/migrate.py
 ## Verification
 
 ```bash
-which python  # Should show .venv/bin/python, NOT /usr/bin/python
+which python   # MUST show .venv/bin/python, NOT /usr/bin/python
+which python3  # Same check — shims resolve python3 independently
+which pytest   # MUST show .venv/bin/pytest
 ```
+
+## MUST Rules
+
+### 1. MUST Address the Venv Interpreter Explicitly
+
+Every invocation MUST resolve through `.venv/bin/python` (explicit),
+`uv run` (resolves via `pyproject.toml`), or an activated shell. Bare
+`python` / `python3` / `python3.13` / `pytest` is BLOCKED — pyenv, asdf,
+and Homebrew all install shims that can resolve to a different
+interpreter than the project `.venv`.
+
+```bash
+# DO
+.venv/bin/python -m pytest tests/
+.venv/bin/python scripts/migrate.py
+uv run pytest tests/
+source .venv/bin/activate && pytest tests/
+
+# DO NOT
+python -m pytest tests/           # which python? unknown
+python3 -m pytest tests/          # pyenv shim — may not be .venv
+python3.13 -c "import foo"        # same
+pytest tests/                     # same — whose pytest?
+```
+
+**BLOCKED rationalizations:**
+
+- "It's fine, `which python` showed the venv earlier"
+- "The shim points at the right version most of the time"
+- "CI uses `python3`, so the test command should match"
+
+**Why:** The pyenv/asdf shim is the #1 cause of "I edited the file but
+tests don't see the change" debugging sessions. An installed package
+that conflicts with your source — e.g. a Python binding for a crate
+you also have in-tree — resolves silently against the wrong code and
+tests "pass" without exercising the edit. Explicit `.venv/bin/python`
+turns a silent correctness bug into a loud `No such file or directory`
+when the venv is missing.
+
+### 2. Monorepo Sub-Packages MUST Be Installed Editable
+
+When a repo contains `packages/*/pyproject.toml`, every sub-package
+MUST be installed editable into the root `.venv` at setup time. A
+`PYTHONPATH=packages/foo/src:packages/bar/src ...` prefix as a
+workaround is BLOCKED.
+
+```bash
+# DO — one-time setup
+uv pip install \
+  -e packages/kailash-dataflow \
+  -e packages/kailash-nexus \
+  -e packages/kailash-kaizen
+
+# DO NOT — PYTHONPATH prefix workaround
+PYTHONPATH=packages/kailash-dataflow/src:packages/kailash-nexus/src \
+  .venv/bin/python -m pytest tests/
+```
+
+**BLOCKED rationalizations:**
+
+- "PYTHONPATH works for this one command"
+- "I'll add the editable install later"
+- "The sub-package has its own pytest config anyway"
+
+**Why:** Editable installs make the sub-package `src/` the canonical
+import path, so editors, type checkers, test runners, and scripts all
+agree on which code runs. A `PYTHONPATH` prefix is invisible to every
+tool except the single command that sets it, leaving IDE jump-to-def,
+Pyright, and ad-hoc scripts pointing at stale or absent installations.
 
 ## Rules
 
@@ -65,3 +136,9 @@ which python  # Should show .venv/bin/python, NOT /usr/bin/python
 - No global/system/Homebrew/pyenv-global Python for project work
 
 **Why:** System Python packages leak into project imports, masking missing dependencies that will crash in CI or on another developer's machine.
+
+- No bare `python` / `python3` / `pytest` — always `.venv/bin/python` or `uv run`
+
+**Why:** See MUST Rule 1 above. Pyenv/asdf/Homebrew shims silently redirect to the wrong interpreter, turning correctness bugs into lost debugging sessions.
+
+Origin: `workspaces/arbor-upstream-fixes/.session-notes` § "Traps / gotchas" (2026-04-11) — pyenv shim resolved `python3` to a different interpreter containing Rust bindings for a package also in source; tests "passed" against the wrong code.

--- a/.claude/rules/schema-migration.md
+++ b/.claude/rules/schema-migration.md
@@ -20,7 +20,7 @@ The schema is the contract between code and data. Every change to that contract 
 
 `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE INDEX`, and any other DDL MUST live in a numbered migration file managed by the project's migration framework (DataFlow auto-migrate, Alembic, ActiveRecord, sqlx, etc.). DDL string literals in **application code** are BLOCKED outside of migration files.
 
-**Scope clarification:** "Application code" means services, controllers, handlers, models, and rake/management tasks. DDL is permitted in: (a) numbered migration files, (b) the dialect helper layer of the Kailash SDK source tree itself (`src/kailash/db/…` patterns like `dialect.blob_type()` and bootstrap table-creation helpers — BUILD repos only, not downstream USE projects), and (c) test fixtures that create and tear down test schemas.
+**Scope clarification:** "Application code" means services, controllers, handlers, models, and rake/management tasks. DDL is permitted in: (a) numbered migration files, (b) the SDK's own dialect helper layer (BUILD repos only — downstream USE projects do not have a dialect helper layer), and (c) test fixtures that create and tear down test schemas.
 
 ```python
 # DO — DataFlow @db.model drives auto-migration; the schema lives in code


### PR DESCRIPTION
## Summary
- Ingested 2 new MUST rules from kailash-py arbor session (python-environment, infrastructure-sql)
- Fixed schema-migration.md USE adaptation (was missing, py template already had it)
- VERSION bumped to 2.5.1

## Test plan
- [x] Non-variant rules match loom globals (verified via diff)
- [x] Variant-overlaid rules match rs variants (verified via diff)
- [x] Zero drift across all rule files

🤖 Generated with [Claude Code](https://claude.com/claude-code)