### PR TITLE
chore(sync): 2.8.0 — kailash-rs 3.15.2 + Aegis identity

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,16 +1,31 @@
 {
-  "version": "2.7.0",
+  "version": "2.8.0",
   "type": "coc-use-template",
   "description": "COC USE template for Python/Ruby developers using Rust-backed Kailash bindings",
   "released": "2026-04-13",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "2.8.1",
-    "build_version": "3.15.1",
+    "version": "2.8.5",
+    "build_version": "3.15.2",
     "synced_at": "2026-04-13T00:00:00+08:00"
   },
   "changelog": [
+    {
+      "version": "2.8.0",
+      "date": "2026-04-13",
+      "summary": "Sync kailash-rs 3.15.2 codify — Aegis identity variant (independence.md), security function name fixes (ApiKeyConfig::validate_key), DataClassification enum fix, cross-binding gap documentation. 5 new global skills, 4 updated variant files.",
+      "changes": [
+        "NEW VARIANT: rules/independence.md — Aegis two-track identity (replaces TF Foundation global for rs target). Origin: session 064a874b.",
+        "UPDATED VARIANT: rules/security.md — validate_token_against_list → ApiKeyConfig::validate_key.",
+        "UPDATED VARIANT: skills/18-security-patterns/constant-time-comparison-rs.md — function name, hash-then-compare invariant, line references.",
+        "UPDATED VARIANT: skills/18-security-patterns/fail-closed-defaults-rs.md — ClassificationLevel → DataClassification, cross-binding gap warning, enum disambiguation.",
+        "NEW GLOBAL: skills/01-core-sdk/runtime-progress.md, runtime-watchdog.md — runtime diagnostics.",
+        "NEW GLOBAL: skills/02-dataflow/cache-cas-fail-closed.md, dataflow-fabric-cache-consumers.md, dataflow-provenance-audit.md.",
+        "UPDATED GLOBAL: rules/dataflow-identifier-safety.md — Rule 5 (hardcoded lists), rules/observability.md, skills/spec-compliance/SKILL.md, guides/co-setup/03-creating-components.md.",
+        "UPDATED GLOBAL: commands/cc-audit.md, commands/sync.md, commands/wrapup.md, skills/30-claude-code-patterns/parallel-merge-workflow.md."
+      ]
+    },
     {
       "version": "2.7.0",
       "date": "2026-04-13",

--- a/.claude/commands/cc-audit.md
+++ b/.claude/commands/cc-audit.md
@@ -5,7 +5,14 @@ description: "Audit project artifacts for quality, completeness, effectiveness, 
 
 # CC Artifact Audit (Project)
 
-Reviews your project's artifacts for quality and template alignment. Checks that project-specific artifacts (agents/project/, skills/project/) are well-formed, and that shared artifacts are current with your upstream template.
+Reviews your repo's artifacts for quality and template alignment. Scope depends on repo type.
+
+## BUILD vs USE Repo Distinction
+
+- **BUILD repos** (kailash-py, kailash-rs, kailash-prism): no `agents/project/` or `skills/project/` directories. Every artifact lives in a canonical location (`agents/frameworks/`, `skills/01-core-sdk/`, etc.) and is subject to the same fidelity checks as loom/. The Phase 1 inventory in a BUILD repo walks ALL artifact directories, not just `project/`.
+- **Downstream USE repos** (consumer projects): project-specific artifacts live in `agents/project/` and `skills/project/`. The Phase 1 inventory focuses on these, since shared artifacts are owned by the upstream template and audited at loom/.
+
+If this repo is a BUILD repo, skip the `project/`-only inventory below and audit all canonical artifact directories.
 
 ## Your Role
 
@@ -13,7 +20,9 @@ Specify scope: `all`, `fidelity` (quality only), `sync` (template alignment only
 
 ## Phase 1: Fidelity Audit
 
-1. **Inventory**: List project-specific artifacts (agents/project/, skills/project/) with line counts.
+1. **Inventory**:
+   - **USE repos**: list project-specific artifacts (`agents/project/`, `skills/project/`) with line counts.
+   - **BUILD repos**: list all canonical artifacts (`agents/**/*.md`, `skills/**/*`, `rules/*.md`, `commands/*.md`) with line counts; `agents/project/` and `skills/project/` should not exist.
 
 2. **Four-dimension audit** per artifact:
    - **Competency**: Precise instructions? Knows its domain?

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -15,15 +15,22 @@ loom/ (source) → kailash-coc-claude-rs/ (USE template) → THIS REPO
                                                               ↑ you are here
 ```
 
+## BUILD vs USE Repo Distinction
+
+- **BUILD repos** (kailash-py, kailash-rs, kailash-prism): artifacts live in canonical locations (`agents/frameworks/`, `skills/01-core-sdk/`, `rules/*.md`). `/codify` writes to canonical locations AND creates `.claude/.proposals/latest.yaml` for upstream flow to loom/. No `agents/project/` or `skills/project/`.
+- **Downstream USE repos** (consumer projects): `/codify` writes project-specific artifacts to `.claude/agents/project/` and `.claude/skills/project/`; stays local.
+
+The "Project-specific" preservation rule below applies only to downstream USE repos. In a BUILD repo every artifact is canonical and subject to merge-review.
+
 ## Merge Semantics
 
 This is a **merge**, not an overwrite. Three categories of files:
 
-| Category             | Examples                                        | Behavior                      |
-| -------------------- | ----------------------------------------------- | ----------------------------- |
-| **Shared artifacts** | agents/analyst.md, rules/security.md            | **Updated** from template     |
-| **Project-specific** | agents/project/_, skills/project/_, workspaces/ | **Preserved** — never touched |
-| **Per-repo data**    | learning/\*, .proposals/                        | **Preserved** — never touched |
+| Category                              | Examples                                          | Behavior                      |
+| ------------------------------------- | ------------------------------------------------- | ----------------------------- |
+| **Shared artifacts**                  | agents/analyst.md, rules/security.md              | **Updated** from template     |
+| **Project-specific** (USE repos only) | agents/project/\*, skills/project/\*, workspaces/ | **Preserved** — never touched |
+| **Per-repo data**                     | learning/\*, .proposals/                          | **Preserved** — never touched |
 
 **Rule**: If a file exists in BOTH the template and this repo, the template version wins (it's the upstream source). If a file exists ONLY in this repo, it's preserved. If a file exists ONLY in the template, it's added.
 
@@ -90,8 +97,7 @@ Compare `.coc-sync-marker` timestamps. If already fresh: "Already up to date."
 
 **Preserved** (never modified by sync):
 
-- `agents/project/**` — project-specific agents
-- `skills/project/**` — project-specific skills
+- `agents/project/**` and `skills/project/**` — project-specific (USE repos only; BUILD repos do not have these directories)
 - `learning/**` — per-repo learning data
 - `.proposals/**` — review artifacts
 - `settings.local.json` — per-repo settings
@@ -129,15 +135,12 @@ Your artifacts are current with the template.
 
 ## Pushing Changes Upstream
 
-If you created knowledge worth sharing (via `/codify`):
+BUILD repos and downstream USE repos behave differently when `/codify` runs:
 
-1. `/codify` creates `.claude/.proposals/latest.yaml`
-2. Open loom/ and run `/sync rs`
-3. Human classifies each change (global vs variant)
-4. `/sync` distributes to USE templates
-5. Other projects pull via their `/sync`
+- **BUILD repos** (kailash-py, kailash-rs, kailash-prism): `/codify` writes to canonical locations (`agents/frameworks/`, `skills/NN-name/`, `rules/*.md`) AND appends entries to `.claude/.proposals/latest.yaml` for upstream flow to loom/. Then open loom/ and run `/sync rs` — Gate 1 classifies each change (global vs variant), Gate 2 distributes to USE templates.
+- **Downstream USE repos** (consumer projects): `/codify` writes to `.claude/agents/project/` and `.claude/skills/project/` and stays LOCAL. No `.proposals/latest.yaml` is created; no upstream flow. These artifacts are preserved across `/sync` runs by the "Project-specific" rule above.
 
-**Never** edit the template directly. All changes flow through loom/.
+**Never** edit the template directly. All shared artifact changes flow through loom/.
 
 ## When to Run
 

--- a/.claude/commands/wrapup.md
+++ b/.claude/commands/wrapup.md
@@ -3,7 +3,7 @@ name: wrapup
 description: "Write .session-notes so the next session resumes without re-discovering context."
 ---
 
-The only deliverable is a `.session-notes` file that lets a fresh session start producing work within 2-3 minutes of reading it, without having to re-explore the codebase.
+The only deliverable is a `.session-notes` file that lets a fresh session start producing work within 2–3 minutes of reading it, without having to re-explore the codebase.
 
 **Before running:** if significant decisions, discoveries, or risks from this session are not yet in `journal/`, run `/journal new DECISION|DISCOVERY|RISK <topic>` first. `.session-notes` is not a decision log.
 
@@ -50,7 +50,7 @@ change. Just enough for the next session to orient — not a history.
 
 1. `path/to/file` — why it matters (one line)
 2. `path/to/file` — why it matters
-   (3-6 files, priority-ordered)
+   (3–6 files, priority-ordered)
 
 ## In-flight state
 

--- a/.claude/guides/co-setup/03-creating-components.md
+++ b/.claude/guides/co-setup/03-creating-components.md
@@ -4,7 +4,7 @@ How to create each component type for any domain.
 
 ## Agents
 
-**Location**: `.claude/agents/` (shared) or `.claude/agents/project/` (project-specific)
+**Location**: `.claude/agents/` (shared) or `.claude/agents/project/` (project-specific). Project-specific agents in `project/` are preserved across `/sync`.
 
 **Purpose**: Specialized sub-processes with deep domain knowledge and procedural directives.
 
@@ -56,7 +56,7 @@ When to hand off to other agents.
 
 ## Skills
 
-**Location**: `.claude/skills/<number>-<name>/` with `SKILL.md` entry point
+**Location**: `.claude/skills/<number>-<name>/` with `SKILL.md` entry point (shared, updated by `/sync`), or `.claude/skills/project/<name>/` for project-specific skills (preserved across `/sync`).
 
 **Purpose**: Distilled domain knowledge that agents reference. The institutional handbook.
 

--- a/.claude/rules/dataflow-identifier-safety.md
+++ b/.claude/rules/dataflow-identifier-safety.md
@@ -109,6 +109,38 @@ async def drop_model(self, model_name: str) -> None:
 
 **Why:** Dropped data is unrecoverable. The explicit flag is the last human gate before destruction; without it, a typo or a mis-scoped rm-equivalent takes the production table with it.
 
+### 5. Hardcoded Identifier Lists MUST Still Validate
+
+Even when an identifier list is a static Python literal in the source file, every element MUST route through `_validate_identifier()` (or `dialect.quote_identifier()`) at the call site before interpolation into DDL. "The list is hardcoded, so it's safe" is BLOCKED.
+
+```python
+# DO — defense-in-depth validation on hardcoded list
+from kailash.db.dialect import _validate_identifier
+
+tables_to_drop = ["users", "roles", "permissions"]
+for table in tables_to_drop:
+    _validate_identifier(table)  # defense-in-depth
+    await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+
+# DO NOT — assume hardcoded means safe
+tables_to_drop = ["users", "roles", "permissions"]
+for table in tables_to_drop:
+    await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+# ↑ works today; breaks the moment someone makes the list dynamic
+# (e.g., reads from config, appends from a function parameter)
+```
+
+**BLOCKED rationalizations:**
+
+- "The list is hardcoded so there's no injection vector"
+- "Adding validation is overkill for a static list"
+- "We'll add validation when the list becomes dynamic"
+- "This is an admin-only path, no attacker can reach it"
+
+**Why:** Hardcoded lists become dynamic lists. A future refactor that reads the table list from a config file, or appends a caller-supplied suffix, or loops over model names from a registry, silently re-opens the injection vector with no test signal because the validation call was never there. The validation call is a permanent marker of intent that survives the refactor.
+
+Origin: Red team review of PR #430 (2026-04-12) surfaced this in `src/kailash/nodes/admin/schema_manager.py::_drop_existing_schema` and `_get_table_row_counts` — hardcoded lists without validation. Fixed in commit 803e10e0.
+
 ## MUST NOT
 
 - Use `f"..."` or `%` formatting to interpolate a dynamic identifier into DDL

--- a/.claude/rules/independence.md
+++ b/.claude/rules/independence.md
@@ -1,44 +1,148 @@
-# Foundation Independence Rules
+# Aegis Identity & Foundation Boundary Rules
 
-Kailash Python SDK is owned by the Terrene Foundation (Singapore CLG). It is an independent open-source product with NO structural relationship to any commercial entity.
+This repository is the **proprietary Aegis Rust SDK**. It is NOT a Terrene Foundation project. The Foundation rules that govern `kailash-py` and `pact` (Apache 2.0, CC BY 4.0, no commercial coupling) DO NOT apply here. This file is the kailash-rs variant override of the global `independence.md` and exists specifically to clarify that boundary.
 
-## No Commercial References
+## The Two-Track Architecture
 
-MUST NOT reference, compare with, or design against any commercial or proprietary product:
+| Track                                | Owner                              | License                                                   | Repos                                                                  |
+| ------------------------------------ | ---------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Aegis (proprietary)**              | Aegis product team                 | `LicenseRef-Proprietary`, trade secret, `publish = false` | **kailash-rs** (this repo), Aegis product applications                 |
+| **Terrene Foundation (open source)** | Terrene Foundation (Singapore CLG) | Apache 2.0 (code), CC BY 4.0 (specs)                      | kailash-py, pact, kailash-coc-claude-{py,rs,rb}, terrene-foundation/\* |
 
-- No proprietary product names, SDKs, runtimes, or frameworks
-- No commercial entities, partnerships, or market positioning
-- No "unlike X", "the open-source version of Y", or "differentiates from Z"
-- No "Python port of", "community edition of", or derivative language
+**Key facts**:
 
-**Why:** Commercial references position Kailash as derivative, undermining its independent identity and potentially creating trademark or legal entanglement.
+1. **kailash-rs is proprietary Aegis product code.** Source is trade secret. Every crate has `publish = false` (except `kailash-plugin-macros` and `kailash-plugin-guest`, the only crates published to crates.io).
+2. **PACT (the open-source governance framework) is Aegis' open-source counterpart**, owned by Terrene Foundation. PACT is one of the four TF standards (CARE + EATP + CO + PACT).
+3. **kailash-py is the TF open-source counterpart of kailash-rs.** The Foundation maintains a full-featured open-source Python SDK (`pip install kailash`); the proprietary Rust SDK is independent of it but consumes the same TF specs.
+4. **TF specs are upstream of both tracks.** CARE, EATP, CO, PACT are CC BY 4.0 — Aegis implements them in proprietary Rust; the TF projects implement them in open-source Python. Neither track owns the specs.
 
-**Describe Kailash on its own terms.** The existence of any other product is irrelevant.
+## MUST Rules
 
-**Correct**: "Kailash Python SDK is the Terrene Foundation's open-source workflow orchestration platform."
-**Incorrect**: "Kailash Python SDK is the Python version of [product name]."
+### 1. Aegis Identity Is Allowed Here
 
-## No Proprietary Awareness
+Unlike `kailash-py` (where commercial references are forbidden under TF independence), this repo is itself a commercial product. You MAY:
 
-- No proprietary file paths, module names, or architecture references
-- No "compatibility" or "interop" with proprietary systems
-- No APIs designed for a specific proprietary product
-- No revenue models, pricing, enterprise vs community splits
+- Refer to "Aegis" as the parent product identity (already canonical per `CLAUDE.md`)
+- Describe `kailash-rs` as "the Aegis Rust SDK"
+- Document that `kailash-rs` is the proprietary implementation paired with the open-source `kailash-py`
 
-**Why:** Proprietary awareness in code or docs creates implicit coupling that constrains future architecture decisions and signals that the SDK serves a specific commercial product.
+```markdown
+# DO — accurate Aegis identity
 
-## Foundation-Only Dependencies
+The kailash-rs crate is part of the proprietary Aegis SDK. Its open-source
+counterpart is kailash-py, owned by the Terrene Foundation.
 
-- Standard open-source libraries (PyPI, OSI-approved licenses)
-- Open standards (CARE, EATP, CO — CC BY 4.0) where applicable
-- MUST NOT depend on, import from, or interface with any proprietary SDK
+# DO NOT — falsely claim TF ownership
 
-**Why:** A proprietary dependency makes every downstream user subject to that vendor's licensing, pricing, and availability decisions, violating the Foundation's independence charter.
+kailash-rs is a Terrene Foundation project. (It is not.)
+```
 
-## Design for SDK Users
+**Why:** Misrepresenting kailash-rs as a TF project violates the Foundation's anti-capture provisions and creates legal ambiguity. Accurately describing it as Aegis-proprietary is correct.
 
-All decisions driven by: what SDK users need, what Python developers expect, what the community contributes. Never by what any other product does or plans to do.
+### 2. TF Specs Are CC BY 4.0 — Implementations Are Separate
 
-**Why:** Designing for a specific commercial consumer rather than SDK users at large biases the API surface, making it awkward for the broader community while optimizing for one party.
+Aegis MAY implement TF specs (CARE, EATP, CO, PACT) in proprietary code. The implementation is trade secret; the spec is CC BY 4.0 and remains owned by the Foundation. Aegis MUST NOT:
 
-Third parties may build commercial products on Kailash. The SDK has zero knowledge of, zero dependency on, and zero design consideration for any such product.
+- Claim ownership of any TF spec
+- Modify a TF spec without upstreaming through the Foundation's process
+- Re-license a TF spec
+- Claim that an Aegis-only extension is part of the TF standard
+
+```rust
+// DO — implementation header
+// Copyright 2026 Aegis (proprietary)
+// SPDX-License-Identifier: LicenseRef-Proprietary
+// Implements EATP v1.0 (Terrene Foundation, CC BY 4.0).
+
+// DO NOT — confused ownership
+// Copyright 2026 Terrene Foundation
+// SPDX-License-Identifier: Apache-2.0
+// (Aegis-proprietary code with TF copyright is misrepresentation.)
+```
+
+**Why:** Conflating spec ownership (TF) with implementation ownership (Aegis) is the structural risk both sides must guard against. The TF spec/Aegis implementation split is the only correct framing.
+
+### 3. Cross-Track References Are Allowed When Accurate
+
+Aegis docs MAY reference `kailash-py` and `pact` as the open-source TF counterparts. The reference must be factual (these projects exist, here is how they relate) and MUST NOT imply a structural relationship beyond "common spec lineage".
+
+```markdown
+# DO — accurate cross-track reference
+
+kailash-rs implements EATP, CARE, CO, and PACT in proprietary Rust.
+The Terrene Foundation maintains open-source counterparts in kailash-py
+(workflow + dataflow + nexus + kaizen) and pact (governance framework).
+Both tracks consume the same upstream specs but are independent in
+implementation, ownership, and release cadence.
+
+# DO NOT — false coupling
+
+kailash-rs ships pre-integrated with kailash-py and is officially
+endorsed by the Terrene Foundation. (Neither claim is true.)
+```
+
+**Why:** Without explicit guidance, agents either over-couple ("Foundation-endorsed") or under-couple ("don't mention kailash-py at all"). The accurate framing is "common spec lineage, independent implementations".
+
+### 4. Aegis Code MUST NOT Be Claimed As TF Code
+
+Marketing copy, README content, license headers, package metadata, and docs MUST never claim that any Aegis crate is "open source" or "Foundation-owned" or under "Apache 2.0". The `LicenseRef-Proprietary` SPDX identifier is mandatory; `Apache-2.0` is BLOCKED on every Aegis crate.
+
+```toml
+# DO — Aegis crate
+[package]
+name = "kailash-dataflow"
+license = "LicenseRef-Proprietary"
+publish = false
+
+# DO NOT — false TF licensing
+[package]
+name = "kailash-dataflow"
+license = "Apache-2.0"  # BLOCKED — this crate is proprietary
+publish = true          # BLOCKED — would leak source to crates.io
+```
+
+**Why:** A single mis-licensed Cargo.toml that says "Apache 2.0" on a proprietary crate, then gets published to crates.io, leaks the source under a license the company never agreed to. The mandatory `LicenseRef-Proprietary` + `publish = false` pair is the structural defense.
+
+**BLOCKED rationalizations:**
+
+- "Apache 2.0 is more permissive, what's the harm?"
+- "The crate is open-source-friendly even if internal"
+- "We can re-license later"
+
+### 5. The Two Crates That ARE Open-Source
+
+`kailash-plugin-macros` and `kailash-plugin-guest` are the only crates in this workspace that publish to crates.io. They MUST be Apache 2.0 OR MIT. They contain only the plugin SDK API surface needed by third-party plugin authors — no Aegis runtime code, no proprietary algorithms.
+
+```toml
+# DO — plugin SDK is genuinely open source
+[package]
+name = "kailash-plugin-guest"
+license = "Apache-2.0 OR MIT"
+publish = true
+```
+
+**Why:** Third-party plugin authors compile against `kailash-plugin-guest` to produce binaries that load into the Aegis runtime. They cannot do this if the dependency is proprietary. The plugin SDK is a deliberate, narrow open-source carve-out — not a precedent for opening other crates.
+
+## MUST NOT
+
+- Apply the `kailash-py` Foundation independence rules verbatim to this repo
+
+**Why:** Those rules forbid commercial product references entirely. Aegis IS a commercial product; applying them to its own repo creates contradictions agents cannot resolve. This variant rule replaces the global rule for kailash-rs.
+
+- Cite `rules/terrene-naming.md` § "Foundation Independence" as governing the Aegis repo's identity
+
+**Why:** That section governs `terrene-foundation/*` repos. Aegis (this repo) is neither owned by nor structurally related to the Foundation; it consumes TF specs but is operated by an independent commercial entity.
+
+- Add Apache 2.0 license headers to Aegis source files
+
+**Why:** Mixed-license source files create legal ambiguity and undermine the trade-secret status of the proprietary code.
+
+## Relationship to other rules
+
+- `rules/release.md` — enforces `publish = false` on every crate except the plugin SDK pair
+- `rules/security.md` § "Source Protection" — covers what must NEVER be published
+- `rules/terrene-naming.md` — the GLOBAL rule for naming TF entities, still applies for any reference TO TF projects from this repo
+- `rules/eatp.md`, `rules/pact-governance.md` — apply to the EATP and PACT _spec implementations_ in this repo (which are subject to Aegis trade-secret rules, NOT TF Apache 2.0 rules)
+- `docs/00-authority/10-source-protection.md` — release auditor's reference for which crates are proprietary
+
+Origin: Aegis/TF boundary clarification, 2026-04-13 (session 064a874b). The previous independence rule was inherited verbatim from the kailash-py loom variant, which produced contradictions between "no commercial product references" and CLAUDE.md's "this is the proprietary Aegis SDK". This variant resolves the contradiction by acknowledging that Aegis IS the parent product brand and replacing the Foundation independence mandate with an accurate Aegis identity model.

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -165,7 +165,52 @@ npm ls --all 2>&1 | grep -iE 'missing|warn|err'
 
 **Why:** Logs that no one reads are worse than no logs at all — they create the illusion of observability while letting the underlying problem fester. Without dedup, a 200-warning test run becomes 200 disposition lines and the agent rationally skips the gate; with dedup, it becomes 5–10 unique entries that are tractable.
 
-### 6. Bulk Operations MUST Log Partial Failures at WARN
+### 6. Mask Helper Output Forms
+
+Credential masking helpers MUST fail loudly and uniformly. A helper that bails on a malformed URL but returns a success-shaped string makes log triage believe the credential was masked when in fact it was written elsewhere.
+
+#### 6.1 Mask Failure Sentinels Distinct From Masked Output
+
+A masking helper that fails to parse its input MUST return a sentinel string distinguishable from any successful mask output. Returning the masked-success template (e.g. `"redis://***"`) on failure is BLOCKED.
+
+```python
+# DO — distinct sentinel
+def mask_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "<unparseable redis url>"  # grep-able failure marker
+    if not parsed.scheme or not parsed.hostname:
+        return "<unparseable redis url>"
+    return f"{parsed.scheme}://***@{parsed.hostname}:{parsed.port or ''}{parsed.path}"
+
+# DO NOT — success-shape on failure
+def mask_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "redis://***"  # looks masked; is actually "helper bailed"
+```
+
+**Why:** A mask helper that returns the success-shape on failure makes log triage believe the credential was masked when in fact the helper bailed and the credential may have been written to a sibling log line. Distinct sentinels surface the failure to grep.
+
+#### 6.2 Mask Form Uniform Across Helpers
+
+All URL-masking helpers in the codebase MUST emit the canonical `scheme://***@host[:port]/path` form. Variant forms (stripping userinfo entirely, masking only password) are BLOCKED.
+
+```python
+# DO — canonical form, grep-able via `***@`
+return f"redis://***@cache:6379/0"
+return f"postgresql://***@db.internal:5432/kailash"
+
+# DO NOT — userinfo stripped; audit cannot find it
+return "redis://cache:6379/0"             # looks like "no credentials" — is actually "stripped"
+return f"postgresql://user:***@db/kailash"  # partial mask leaks username
+```
+
+**Why:** A grep audit for credential leakage searches for `***@`. Helpers that strip userinfo silently bypass that audit. Uniform output form is what makes the masking layer auditable at all.
+
+### 7. Bulk Operations MUST Log Partial Failures at WARN
 
 Any bulk operation (BulkCreate, BulkUpdate, BulkDelete, BulkUpsert) that catches per-row exceptions MUST emit at least one WARN-level log line when `failed > 0`, including: operation name, total rows, failure count, and a sample error. Exception handlers in bulk ops MUST NOT use `except Exception: continue` or `except Exception: pass` without a WARN log.
 
@@ -186,9 +231,50 @@ except Exception:
 **Why:** Source audit confirmed: `BulkCreate._handle_batch_error()` has `except Exception: continue` with zero logging; `BulkUpsert` uses `print()` instead of a structured logger. A bulk op returning `failed: 10663` with no WARN line is invisible to alerting pipelines. See 0052-DISCOVERY §2.1 and `guides/deterministic-quality/06-observability-primitives.md` §2.
 
 **BLOCKED responses:**
+
 - "The caller will see the return value, no log needed"
 - "We return a failure list, that's enough"
 - "We already log at DEBUG"
+
+### 8. Schema-Revealing Field Names MUST Be Logged At DEBUG Or Hashed
+
+Structured log lines that emit schema-level identifiers (model names, column names, field names from classification/masking/validation code paths) MUST be logged at DEBUG level — not WARN or INFO. If an operational WARN is genuinely needed for the condition, emit a counter or a hash, not the raw field name.
+
+```python
+# DO — schema names at DEBUG only; operational signal via counter
+logger.debug(
+    "classification.default_applied",
+    extra={"model": model_name, "field": field_name, "default": default},
+)
+# Operators who need to audit unclassified fields enable DEBUG.
+metrics.classification_defaults.inc()  # operational signal without field name
+
+# DO — hash when WARN is required
+field_hash = hashlib.sha256(f"{model_name}.{field_name}".encode()).hexdigest()[:8]
+logger.warning(
+    "classification.default_applied",
+    extra={"field_hash": field_hash, "default": default},
+)
+
+# DO NOT — schema names at WARN bleed into log aggregators
+logger.warning(
+    "classification.default_applied",
+    extra={"model": "users", "field": "ssn", "default": "public"},
+)
+# ↑ any log aggregator with broader access than the database now knows
+# the schema has `users.ssn`, which is schema-level sensitive info
+```
+
+**BLOCKED responses:**
+
+- "The field name isn't the value, it's just the schema"
+- "Operators need to see which fields are unclassified"
+- "Log aggregator access is the same as database access"
+- "DEBUG is off in prod, nobody will see it"
+
+**Why:** Log aggregators (Datadog, Splunk, CloudWatch) are typically accessible to a broader audience than the production database — SREs, on-call engineers, support staff, third-party observability vendors. A WARN log containing `field=ssn` reveals the schema has an `ssn` column to everyone with log read permission, even if the VALUES never leak. Classification metadata is itself schema-level PII-adjacency. DEBUG-level field names stay out of alerting paths and routine dashboards; operators who need to audit unclassified fields enable DEBUG explicitly for the audit window.
+
+Origin: Red team review of PR #430 (2026-04-12) flagged `packages/kailash-dataflow/src/dataflow/classification/policy.py::ClassificationPolicy.classify` emitting field names at WARN. Downgraded to DEBUG in commit 62d64ac7.
 
 ## MUST NOT
 

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -127,11 +127,11 @@ All user-generated content MUST be encoded before display in HTML templates, JSO
 
 ## Rust: Credential Comparison (MUST)
 
-Every credential / token / HMAC / API key comparison in Rust code MUST use `kailash_auth::validate_token_against_list` (list) or `kailash_auth::constant_time_eq` (single) — NEVER `==`, NEVER `.any()` over a constant-time inner comparison.
+Every credential / token / HMAC / API key comparison in Rust code MUST use `kailash_auth::api_key::ApiKeyConfig::validate_key` (list) or `kailash_auth::constant_time_eq` (single) — NEVER `==`, NEVER `.any()` over a constant-time inner comparison.
 
 ```rust
 // DO — single helper, always walks full list
-let ok = kailash_auth::validate_token_against_list(token, valid_keys);
+let ok = kailash_auth::api_key::ApiKeyConfig::validate_key(token, valid_keys);
 
 // DO NOT — .any() short-circuits, leaks match position via timing
 let ok = valid_keys.iter().any(|k| constant_time_eq(token, k));

--- a/.claude/skills/01-core-sdk/runtime-progress.md
+++ b/.claude/skills/01-core-sdk/runtime-progress.md
@@ -1,0 +1,80 @@
+# Runtime Progress Tracking
+
+ProgressRegistry provides structured progress reporting for long-running node
+operations. Nodes emit updates via `report_progress()`, and registered callbacks
+(UIs, loggers, metrics) receive them in real time.
+
+## Architecture
+
+```
+Node.run()                     ProgressRegistry              Callbacks
+    │                               │                           │
+    ├─ report_progress(1, 100) ──►  emit(ProgressUpdate) ──►  on_progress(update)
+    ├─ report_progress(2, 100) ──►  emit(ProgressUpdate) ──►  on_progress(update)
+    │                               │                           │
+    └─ (node completes)             └─ (bounded deque)          └─ (UI/log/metric)
+```
+
+- **Context variables** (`contextvars`) propagate the registry and current node ID
+  implicitly through the async call stack — nodes don't need a reference to the runtime.
+- **Thread-safe** — `threading.Lock` protects callback registration; bounded `deque`
+  prevents OOM on long workflows.
+- **Backward compatible** — `report_progress()` is a no-op when no registry is active.
+
+## API Surface
+
+```python
+from kailash.runtime.progress import ProgressUpdate, ProgressRegistry, report_progress
+
+# ProgressUpdate (dataclass)
+update.node_id      # str — which node emitted this
+update.current      # int — items processed so far
+update.total        # int | None — total items (None = indeterminate)
+update.message      # str — human-readable status
+update.timestamp    # float — time.monotonic()
+update.fraction     # float | None — current/total (property)
+
+# ProgressRegistry
+registry = ProgressRegistry()
+registry.register(callback)    # Callable[[ProgressUpdate], None]
+registry.unregister(callback)
+registry.emit(update)          # broadcast to all callbacks
+registry.clear()               # remove all callbacks
+
+# Convenience function (called inside Node.run())
+report_progress(current=50, total=100, message="Processing batch 5/10")
+```
+
+## Production Wiring (LocalRuntime)
+
+LocalRuntime creates a `ProgressRegistry` at init and wires it into the
+execution context via `_current_progress_registry` context variable:
+
+```python
+# Consumer side — register a callback before execution
+def on_progress(update: ProgressUpdate):
+    print(f"[{update.node_id}] {update.fraction:.0%} — {update.message}")
+
+runtime = LocalRuntime()
+runtime.progress_registry.register(on_progress)
+results, run_id = runtime.execute(workflow.build())
+```
+
+## Writing Progress-Aware Nodes
+
+Inside a custom node's `run()` method:
+
+```python
+from kailash.runtime.progress import report_progress
+
+class BatchProcessNode(BaseNode):
+    async def run(self, inputs):
+        items = inputs["items"]
+        for i, item in enumerate(items):
+            await self.process(item)
+            report_progress(current=i + 1, total=len(items), message=f"Item {item.id}")
+        return {"processed": len(items)}
+```
+
+`report_progress` reads the context variable set by the runtime. If no registry
+is active (e.g., running the node in isolation), the call is a silent no-op.

--- a/.claude/skills/01-core-sdk/runtime-watchdog.md
+++ b/.claude/skills/01-core-sdk/runtime-watchdog.md
@@ -1,0 +1,67 @@
+# Event Loop Watchdog
+
+EventLoopWatchdog detects asyncio event loop stalls — situations where the loop
+stops processing callbacks within a configurable threshold. This is the primary
+diagnostic tool for hung workflows in LocalRuntime.
+
+## Architecture
+
+Two-part design:
+
+1. **Heartbeat coroutine** (inside the event loop) — posts timestamps at regular intervals.
+2. **Watchdog thread** (outside the event loop) — checks whether heartbeats arrive on time.
+
+When the gap between heartbeats exceeds the stall threshold, the watchdog captures
+task stack traces and fires an `on_stall` callback with a structured `StallReport`.
+
+## API Surface
+
+```python
+from kailash.runtime.watchdog import EventLoopWatchdog, StallReport
+
+# StallReport (dataclass)
+report.stall_duration_s   # float — how long the loop has been unresponsive
+report.loop_id            # int — id() of the event loop
+report.task_count         # int — number of tasks in the loop
+report.task_stacks        # list[str] — stack traces of running tasks
+report.timestamp          # datetime — when the stall was detected
+
+# EventLoopWatchdog
+wd = EventLoopWatchdog(
+    loop=asyncio.get_event_loop(),
+    heartbeat_interval_s=1.0,     # how often the heartbeat fires
+    stall_threshold_s=5.0,        # gap that triggers a stall report
+    on_stall=my_callback,         # Callable[[StallReport], None]
+)
+await wd.start()
+# ... run workflow ...
+await wd.stop()
+
+# Properties
+wd.is_stalled       # bool — is the loop currently stalled?
+wd.stall_reports    # deque[StallReport] — historical stall reports
+```
+
+## Recommended Usage (Context Manager)
+
+```python
+async with EventLoopWatchdog(
+    stall_threshold_s=3.0,
+    on_stall=lambda r: logger.warning("loop.stall", duration=r.stall_duration_s),
+) as wd:
+    results, run_id = await runtime.execute_workflow_async(workflow.build())
+    if wd.is_stalled:
+        logger.error("Loop stalled during execution", stacks=wd.stall_reports[-1].task_stacks)
+```
+
+## Resource Cleanup
+
+EventLoopWatchdog implements `__del__` with `ResourceWarning` per `rules/patterns.md`.
+If `stop()` is not called before garbage collection, a warning is emitted and the
+watchdog thread receives a best-effort stop signal.
+
+## When to Use
+
+- **Production monitoring**: Detect blocked event loops in Docker/FastAPI deployments
+- **CI diagnostics**: Add to integration tests that occasionally hang to capture what's blocking
+- **Development**: Wrap long-running workflow executions to catch accidental sync calls in async nodes

--- a/.claude/skills/02-dataflow/cache-cas-fail-closed.md
+++ b/.claude/skills/02-dataflow/cache-cas-fail-closed.md
@@ -1,0 +1,95 @@
+---
+name: Cache CAS fail-closed pattern
+description: When a CAS (compare-and-swap) primitive can only be satisfied by one backend, reject at the API boundary instead of silently degrading across backends.
+---
+
+# Cache CAS Fail-Closed Pattern
+
+When a cache primitive offers compare-and-swap semantics but the CAS tracking state lives in-process, the operation is ONLY correct on the in-process memory backend. For Redis, Memcached, or hybrid backends, the in-process version tag has no atomicity guarantee — two processes sharing the Redis instance each maintain independent version dicts, and the CAS check becomes meaningless.
+
+The fail-closed pattern: reject the CAS request at the outer API boundary when the backend cannot satisfy it atomically. Do NOT allow the request to proceed, silently ignore `expected_version`, or produce misleading success on a non-atomic write.
+
+## The Pattern
+
+```python
+async def async_run(self, **kwargs) -> Dict[str, Any]:
+    operation = kwargs["operation"].lower()
+    backend = CacheBackend(kwargs.get("backend", "memory"))
+
+    # Fail-closed guard BEFORE any backend init.
+    # CAS (expected_version) is only supported with memory backend.
+    if (
+        operation == "set"
+        and kwargs.get("expected_version") is not None
+        and backend != CacheBackend.MEMORY
+    ):
+        return {
+            "success": False,
+            "cas_failed": True,
+            "error": (
+                "CAS (expected_version) is only supported with "
+                "backend='memory'. Redis and hybrid backends require "
+                "server-side CAS (e.g., Redis WATCH/MULTI)."
+            ),
+        }
+    # ... rest of execution
+```
+
+## Key points
+
+1. **Reject at the outer boundary** — before backend initialization, so we don't even attempt to connect to a Redis we can't correctly serve. This keeps error paths cheap and fails fast.
+
+2. **Return structured error, not exception** — the caller gets `success=False`, `cas_failed=True`, and an error message directing them to server-side CAS. The existing error-handling contract (not a new exception class) is preserved.
+
+3. **Direct the caller to the correct API** — the error message names the alternative (Redis WATCH/MULTI). This converts the failure into actionable guidance, not a dead-end.
+
+4. **Test both directions** — a regression test must verify (a) CAS works correctly on memory backend, (b) CAS is rejected with a clear error on every other backend. See `tests/regression/test_cache_cas_tenant.py::TestCacheCASRace::test_cas_rejected_on_redis_backend`.
+
+## When to use
+
+This pattern applies any time a primitive's correctness depends on state that only one backend can provide:
+
+- **CAS / optimistic locking** — in-process version tags only work for in-process backends
+- **Transactional multi-key writes** — local transaction only applies to local backend
+- **Last-writer-wins timestamps** — local clock only authoritative for local backend
+- **Structural guarantees** — e.g. "exactly-once delivery" that relies on an in-process dedup set
+
+## When NOT to use (false positives)
+
+- **Backend-agnostic primitives** — `get`, `set`, `delete`, `exists` work identically across backends; don't reject them.
+- **Primitives with a correct multi-backend implementation** — if you can implement CAS correctly on Redis via WATCH/MULTI, implement it; don't just reject.
+
+## Anti-patterns
+
+```python
+# BLOCKED — silently ignore expected_version on non-memory backends
+async def _set(self, kwargs):
+    expected_version = kwargs.get("expected_version")
+    if expected_version is not None:
+        current = self._version_tags.get(key)  # empty dict for Redis
+        if current != expected_version:
+            return {"cas_failed": True}
+    # write to Redis without CAS check at all
+    await self._redis_set(...)
+# ↑ for Redis: _version_tags is empty, current is always None,
+# CAS check passes when expected_version is None, silently bypasses guarantee
+
+# BLOCKED — raise NotImplementedError deep in the call stack
+async def _set(self, kwargs):
+    expected_version = kwargs.get("expected_version")
+    backend = kwargs["backend"]
+    if expected_version is not None and backend != "memory":
+        raise NotImplementedError("CAS only works with memory")
+# ↑ by the time this fires, the caller is deep in a workflow and
+# the error surfaces as an uncaught exception, not an API contract
+
+# BLOCKED — fall back to non-CAS write when backend can't support it
+if expected_version is not None and backend != "memory":
+    logger.warning("CAS not supported on this backend, ignoring")
+    # fall through to regular write
+# ↑ the caller thinks their CAS succeeded; concurrent writer clobbers them
+```
+
+## Origin
+
+PR #430 red team review (2026-04-12) surfaced the silent-degradation pattern in `src/kailash/nodes/cache/cache.py::CacheNode._set`. Fixed in commits bd411c44 and 62d64ac7. Tests in `tests/regression/test_cache_cas_tenant.py`.

--- a/.claude/skills/02-dataflow/dataflow-fabric-cache-consumers.md
+++ b/.claude/skills/02-dataflow/dataflow-fabric-cache-consumers.md
@@ -1,0 +1,83 @@
+---
+description: Data Fabric cache control, consumer adapters, and MCP tool generation
+---
+
+# Fabric Cache Control + Consumer Adapters
+
+## Cache Control
+
+```python
+# Invalidate specific product cache
+db.fabric.invalidate("portfolio_snapshot")
+
+# Invalidate with params (parameterized products)
+db.fabric.invalidate("users", params={"region": "us"})
+
+# Clear all caches
+count = db.fabric.invalidate_all()
+
+# Per-request cache bypass
+# GET /fabric/portfolio?refresh=true
+```
+
+## Consumer Adapters
+
+Transform canonical product data into consumer-specific views.
+
+```python
+# Register consumer transforms (pure functions)
+db.fabric.register_consumer("maturity_report", to_maturity_report)
+db.fabric.register_consumer("chat_summary", to_chat_summary)
+
+# Declare supported consumers on products
+@db.product("portfolio", consumers=["maturity_report", "chat_summary"])
+async def portfolio(ctx):
+    return {"loans": [...], "market": {...}}
+
+# Access consumer views
+# GET /fabric/portfolio                      → canonical data
+# GET /fabric/portfolio?consumer=maturity_report → transformed data
+# X-Fabric-Consumer header set when consumer used
+```
+
+## MCP Tool Generation
+
+```python
+# Auto-generate MCP tools from products
+tools = db.fabric.get_mcp_tools()
+# Returns list of MCP tool definitions: get_portfolio, get_dashboard, etc.
+
+# Optional: register with MCP server
+from dataflow.fabric.mcp_integration import register_with_mcp
+register_with_mcp(db.fabric, mcp_server)
+```
+
+## Fabric-Only Mode
+
+```python
+# No database required — just sources + products
+db = DataFlow()  # database_url=None
+db.source("loans", MyAdapter("loans"))
+
+@db.product("summary", mode="virtual", depends_on=["loans"])
+async def summary(ctx):
+    return await ctx.source("loans").fetch("active")
+
+await db.start(dev_mode=True, prewarm=True)
+```
+
+## Virtual Products
+
+Virtual products execute inline on every request (never cached):
+
+```python
+@db.product("active_count", mode="virtual", depends_on=["loans"])
+async def active_count(ctx):
+    return {"count": len(await ctx.source("loans").fetch("active"))}
+```
+
+## Graceful Shutdown
+
+```python
+await db.fabric.drain(timeout=30.0)  # Wait for in-flight pipelines
+```

--- a/.claude/skills/02-dataflow/dataflow-provenance-audit.md
+++ b/.claude/skills/02-dataflow/dataflow-provenance-audit.md
@@ -1,0 +1,65 @@
+---
+description: DataFlow Provenance[T] field tracking and audit trail persistence
+---
+
+# Provenance + Audit Trail
+
+## Provenance[T] — Field-Level Source Tracking
+
+```python
+from dataflow.core.provenance import Provenance, ProvenanceMetadata, SourceType
+
+# Create with provenance
+metadata = ProvenanceMetadata(
+    source_type=SourceType.API_QUERY,
+    source_detail="CRM API /contacts endpoint",
+    confidence=0.95,
+    change_reason="Quarterly refresh",
+)
+field = Provenance(value=70_000_000.0, metadata=metadata)
+
+# Validation enforced
+# confidence must be 0.0-1.0 and math.isfinite()
+# source_type must be valid SourceType enum
+# extracted_at defaults to datetime.now(UTC)
+```
+
+### SourceType Enum
+
+`EXCEL_CELL`, `API_QUERY`, `CALCULATED`, `AGENT_DERIVED`, `MANUAL`, `DATABASE`, `FILE`
+
+### Serialization
+
+```python
+d = field.to_dict()   # {"value": 70000000.0, "source_type": "api_query", "confidence": 0.95, ...}
+f = Provenance.from_dict(d)  # Round-trip
+```
+
+## Audit Trail Persistence
+
+```python
+# Enable audit persistence (auto-creates audit_events table)
+db = DataFlow("sqlite:///app.db", audit=True)
+await db.start()
+
+# Query audit trail
+events = await db.audit.query(
+    entity_type="LoanEntry",
+    entity_id="loan-001",
+    start_time=datetime(2026, 3, 1, tzinfo=UTC),
+    end_time=datetime(2026, 4, 1, tzinfo=UTC),
+)
+
+# Convenience method
+trail = await db.audit.get_trail("LoanEntry", "loan-001")
+```
+
+### EventStoreBackend
+
+- `SQLiteEventStore` — WAL mode, indexed on (entity_type, entity_id), (timestamp)
+- `PostgreSQLEventStore` — JSONB columns, asyncpg (optional dependency)
+- Both auto-created on `DataFlow.start(audit=True)`
+
+### datetime Note
+
+All audit code uses `datetime.now(UTC)` — NOT `datetime.utcnow()` (deprecated since Python 3.12).

--- a/.claude/skills/18-security-patterns/constant-time-comparison-rs.md
+++ b/.claude/skills/18-security-patterns/constant-time-comparison-rs.md
@@ -28,26 +28,36 @@ fn validate_api_key(token: &str, valid_keys: &[String]) -> bool {
 
 ## The Helper
 
-The canonical helper lives in `kailash-auth/src/api_key.rs:116-121`. Every Rust crate that validates credentials MUST route through this helper, not re-implement it.
+The canonical helper lives in `kailash-auth/src/api_key.rs:114` as a method on `ApiKeyConfig`. Every Rust crate that validates credentials MUST route through this helper, not re-implement it.
 
 ```rust
-// kailash-auth/src/api_key.rs (canonical)
-pub fn validate_token_against_list(token: &str, valid: &[impl AsRef<str>]) -> bool {
-    let mut found = false;
-    for v in valid {
-        found |= constant_time_eq(token, v.as_ref());
+// kailash-auth/src/api_key.rs:114 (canonical, exact)
+impl ApiKeyConfig {
+    /// Returns true if the given key matches any valid key hash
+    /// using constant-time comparison.
+    pub fn validate_key(&self, key: &str) -> bool {
+        let incoming_hash = sha256_hash(key.as_bytes());
+        let mut found = 0u8;
+        for stored in &self.valid_key_hashes {
+            found |= u8::from(bool::from(incoming_hash.ct_eq(stored)));
+        }
+        found != 0
     }
-    found
 }
 ```
 
-**Why a single helper**: the R3 finding was a duplicate implementation drift. `kailash-nexus/src/mcp/auth.rs` had its own `constant_time_eq` and its own validation loop. The duplicate was "correct" in isolation but had the `.any()` bug. A single helper is the only audit point that survives refactors.
+Two invariants enforce constant-time behavior:
+
+1. **Bitwise OR accumulation** — the loop walks the FULL `valid_key_hashes` list every call, OR-ing `ct_eq` results into `found`. No early return, no `.any()`.
+2. **Hash-then-compare** — the incoming key is hashed before comparison; stored `valid_key_hashes` are SHA-256 hashes (not raw keys). This prevents length-based side-channels and protects the stored key material at rest.
+
+**Why a single helper**: the R3 finding was a duplicate implementation drift. `kailash-nexus/src/mcp/auth.rs` had its own constant-time comparison and its own validation loop. The duplicate was "correct" in isolation but had the `.any()` bug. A single helper is the only audit point that survives refactors.
 
 ## Enforcement Checklist
 
 Before adding any credential / token / HMAC comparison to a Rust crate:
 
-1. **Use `kailash_auth::validate_token_against_list`** for list comparisons.
+1. **Use `kailash_auth::api_key::ApiKeyConfig::validate_key`** for list comparisons, NOT `.any()` over an inner constant-time helper.
 2. **Use `subtle::ConstantTimeEq`** (via `kailash_auth::constant_time_eq`) for single comparisons — NOT `==` on `&str`, `&[u8]`, or `String`.
 3. **Never short-circuit** a credential loop via `.any()`, `.find()`, `.position()`, or early `return true`.
 4. **Add a regression test** in `tests/regression/` that asserts the loop walks the full list. Test pattern:
@@ -58,9 +68,9 @@ Before adding any credential / token / HMAC comparison to a Rust crate:
        // First key matches; verify full list still walked by asserting
        // behavior on a list where later entries are invalid patterns.
        let valid = vec!["match".to_string(), "".to_string(), "x".to_string()];
-       assert!(validate_token_against_list("match", &valid));
+       assert!(validate_key("match", &valid));
        // Timing-invariant: same function also returns false for non-match
-       assert!(!validate_token_against_list("nope", &valid));
+       assert!(!validate_key("nope", &valid));
    }
    ```
 

--- a/.claude/skills/18-security-patterns/fail-closed-defaults-rs.md
+++ b/.claude/skills/18-security-patterns/fail-closed-defaults-rs.md
@@ -15,29 +15,54 @@ For every security-adjacent type, ask: **"If the operator forgets to configure t
 
 ### 1. Thread-Local Clearance Default
 
+**Canonical implementation**: `crates/kailash-dataflow/src/classification.rs:55-121`. The DataFlow caller clearance uses `DataClassification` (variants `Public, Internal, Sensitive, PII, GDPR, HighlyConfidential`), NOT `kailash-governance::ClassificationLevel` (which is a separate enum for PACT clearance gradient).
+
 ```rust
-// DO — fail-closed: missing clearance means Public, not HighlyConfidential
+// DO — fail-closed: default is the LOWEST clearance (Public), not the highest
+// crates/kailash-dataflow/src/classification.rs:73-79
 thread_local! {
-    static CALLER_CLEARANCE: Cell<ClassificationLevel> = const {
-        Cell::new(ClassificationLevel::Public)
-    };
+    static CALLER_CLEARANCE: RefCell<DataClassification> =
+        const { RefCell::new(DataClassification::Public) };
 }
 
-// DO NOT — fail-open: any thread that forgot set_caller_clearance
+// Scoped installation — rolls back on panic via Drop
+pub fn with_caller_clearance<F, R>(level: DataClassification, f: F) -> R
+where F: FnOnce() -> R
+{
+    let prev = CALLER_CLEARANCE.with(|c| std::mem::replace(&mut *c.borrow_mut(), level));
+    let _guard = scopeguard::guard((), |_| {
+        CALLER_CLEARANCE.with(|c| *c.borrow_mut() = prev);
+    });
+    f()
+}
+
+// DO NOT — fail-open: any thread that forgot with_caller_clearance
 // reads unredacted PII, silently.
 thread_local! {
-    static CALLER_CLEARANCE: Cell<ClassificationLevel> =
-        Cell::new(ClassificationLevel::HighlyConfidential);
+    static CALLER_CLEARANCE: RefCell<DataClassification> =
+        const { RefCell::new(DataClassification::HighlyConfidential) };
 }
 ```
 
 **Why**: Operators enable classification believing PII will be redacted. With a fail-open default, PII is only redacted when the caller _explicitly_ sets a clearance level — which is effectively never in default configurations. The entire security feature becomes a no-op.
 
+**Read-path enforcement**: `apply_read_classification` in the same file masks any field whose sensitivity is strictly above `current_caller_clearance()`. A `Public` caller sees redacted values for Internal/Sensitive/PII/GDPR/HighlyConfidential. A `HighlyConfidential` caller sees every field verbatim.
+
+**Note on enum naming**: Three Classification enums exist in the workspace — do not confuse them:
+
+- `kailash-dataflow::DataClassification` — PII/redaction tagging (`Public, Internal, Sensitive, PII, GDPR, HighlyConfidential`). This is the one used for read-path masking.
+- `kailash-governance::ClassificationLevel` — clearance gradient for PACT (`Public=0, Restricted=1, Confidential=2, Secret=3, TopSecret=4`).
+- `eatp::constraints::DataClassification` — constraint-layer enum (`Public, Internal, Confidential, Restricted, TopSecret`).
+
 ### 2. Registry / Delegation: Reject Duplicates
+
+**Cross-binding gap — this fix is currently Python-only.** The R1 H2 fix for `EatpAuthorityRegistry` duplicate-rejection lives at `bindings/kailash-python/src/eatp.rs:2417-2510`. The Rust `crates/eatp/` crate has **no `AuthorityRegistry` type at all**. Ruby, Node.js, WASM, C ABI, and Rust-native callers of `crates/eatp/` directly have zero duplicate-rejection protection. This is tracked as a HIGH outstanding gap in `specs/bindings.md` and needs backporting.
+
+The pattern below is the CORRECT shape — use it when you backport to the Rust crate, or when adding duplicate-rejection to any other registry type in the workspace (delegation, key store, posture registry, etc.).
 
 ```rust
 // DO — register rejects duplicates; intentional rotation uses replace(force_replace=true)
-impl EatpAuthorityRegistry {
+impl AuthorityRegistry {
     pub fn register(&mut self, id: AuthorityId, key: VerifyingKey) -> Result<(), RegistryError> {
         if self.entries.contains_key(&id) {
             return Err(RegistryError::DuplicateAuthority(id));
@@ -58,7 +83,7 @@ impl EatpAuthorityRegistry {
 }
 
 // DO NOT — blind overwrite hijacks delegation chains
-impl EatpAuthorityRegistry {
+impl AuthorityRegistry {
     pub fn register(&mut self, id: AuthorityId, key: VerifyingKey) {
         self.entries.insert(id, key);  // silently replaces existing
     }
@@ -66,6 +91,8 @@ impl EatpAuthorityRegistry {
 ```
 
 **Why**: A single registry-write permission must not escalate to full delegation control. Blind overwrite means any authority holder can impersonate any other authority by re-registering with a new key.
+
+**Python binding reference implementation**: the Python shim at `bindings/kailash-python/src/eatp.rs:2417-2510` wraps an internal HashMap + duplicate check + `force_replace` parameter. When backporting to Rust, the shape should match so the binding can delegate through. Regression test lives at `bindings/kailash-python/tests/regression/test_h2_authority_register_hijack.py`.
 
 ### 3. File Permissions: 0o600 on Sensitive Files
 
@@ -184,6 +211,8 @@ Any match that cannot cite a fail-closed default OR an explicit `force_*` flag f
 - `rules/security.md` — top-level security rules
 - `rules/trust-plane-security.md` — trust-plane-specific fail-closed patterns
 - `skills/18-security-patterns/constant-time-comparison-rs.md` — companion rule on credential comparison
-- `crates/eatp/src/authority_registry.rs` — canonical fail-closed registry implementation
-- `crates/kailash-dataflow/src/classification.rs` — fail-closed clearance default
-- `crates/kailash-align-serving/src/backend/llama_cpp.rs` — canonical path containment
+- `crates/kailash-dataflow/src/classification.rs:55-121` — canonical fail-closed clearance default + RAII installer
+- `crates/kailash-align-serving/src/backend/llama_cpp.rs:81,91,233-293,315-328` — canonical path containment + FFI Sync invariant
+- `crates/kailash-enterprise/src/audit/sqlite.rs:160-218` — canonical 0o600 tightening + regression test at :1005-1022
+- `bindings/kailash-python/src/eatp.rs:2417-2510` — Python-only `EatpAuthorityRegistry` duplicate-rejection (R1 H2 fix). **Note:** no Rust equivalent exists yet — Rust crate `crates/eatp/` has no `AuthorityRegistry` type; backporting is a tracked security task.
+- `bindings/kailash-python/tests/regression/test_h2_authority_register_hijack.py` — regression test for the Python-side fix

--- a/.claude/skills/29-pact/SKILL.md
+++ b/.claude/skills/29-pact/SKILL.md
@@ -1,68 +1,85 @@
 ---
-name: 29-pact
-description: "PACT governance — MANDATORY for ALL governance, RBAC, policy, access control, and audit work. D/T/R accountability, operating envelopes, knowledge clearance, MCP tool policy, governed agents. Use proactively when work touches RBAC, roles, permissions, access enforcement, audit trails, governed agents, policy decisions, or 'just a quick authz check'. Custom policy code, hand-rolled RBAC, ad-hoc audit logging BLOCKED."
+name: pact
+description: "PACT governance framework patterns for D/T/R addressing, knowledge clearance, operating envelopes, 5-step access enforcement, 4-zone gradient verification, GovernanceEngine, PactGovernedAgent, and cross-language bindings. Use when working with kailash.pact or pact binding modules."
 ---
 
-# PACT Governance Skills
+# PACT Governance Framework Patterns
 
-Quick reference for PACT organizational governance patterns.
+Principled Architecture for Constrained Trust (PACT) -- organizational governance for AI agents. D/T/R addressing, knowledge clearance, operating envelopes, access enforcement, and verification gradient.
 
-## Install
+**Python module**: `kailash.pact` (backed by Rust implementation, source-available BSL 1.1)
+**Depends on**: `kailash.governance` + `kailash.eatp` (governance engine and EATP protocol)
+**Tests**: 1,396+ (governance 565 + eatp 58 + pact 58 + Python 109 + bridge enforcement 10)
+**PyO3**: `from kailash import PactGovernanceEngine, PactAddress, PactDimensionName, PactVacancyDesignation, PactBridgeApprovalStatus`
 
-```bash
-pip install kailash-pact          # Governance framework
-pip install kailash>=2.0.0        # Core SDK with trust subsystem
-pip install kailash-kaizen>=2.0.0 # For governed Kaizen agents
-```
+## Reference Documentation
 
-## Skill Files
+### Core Concepts
 
-| Skill                                                     | Use When                                                                                              |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [pact-quickstart](pact-quickstart.md)                     | Getting started, first GovernanceEngine                                                               |
-| [pact-governance-engine](pact-governance-engine.md)       | Engine API, verify_action, compute_envelope                                                           |
-| [pact-dtr-addressing](pact-dtr-addressing.md)             | D/T/R grammar, Address parsing                                                                        |
-| [pact-envelopes](pact-envelopes.md)                       | Three-layer model, monotonic tightening                                                               |
-| [pact-access-enforcement](pact-access-enforcement.md)     | 5-step algorithm, clearance, bridges, KSPs                                                            |
-| [pact-governed-agents](pact-governed-agents.md)           | PactGovernedAgent, @governed_tool                                                                     |
-| [pact-kaizen-integration](pact-kaizen-integration.md)     | Wrapping Kaizen agents with governance                                                                |
-| [pact-mcp-governance](pact-mcp-governance.md)             | MCP tool governance: enforce, audit, middleware                                                       |
-| [pact-enforcement-modes](pact-enforcement-modes.md)       | ENFORCE/SHADOW/DISABLED modes, HELD verdict handling, envelope adapter                                |
-| [pact-conformance-features](pact-conformance-features.md) | N1-N6: KnowledgeFilter, EnvelopeCache, PlanSuspension, AuditTiers, ObservationSink, cross-SDK vectors |
+- **[pact-quick-start](pact-quick-start.md)** -- Define org, grant clearance, check access, verify action
+- **[pact-dtr-addressing](pact-dtr-addressing.md)** -- D/T/R address grammar, parsing, ancestors, LCA
+- **[pact-access-algorithm](pact-access-algorithm.md)** -- 5-step fail-closed algorithm with containment sub-paths (3a-3e)
+- **[pact-envelope-model](pact-envelope-model.md)** -- 3-layer envelope model, intersection rules, posture defaults
 
-## Key Types
+### API and Integration
 
-```python
-from kailash.trust.pact import GovernanceEngine, GovernanceVerdict
-from kailash.trust.pact.config import (
-    ConstraintEnvelopeConfig, OrgDefinition,
-    TrustPostureLevel, VerificationLevel,
-    ConfidentialityLevel,
-)
-from kailash.trust.pact.agent import PactGovernedAgent
-from kailash.trust.pact.audit import AuditChain
+- **[pact-engine-api](pact-engine-api.md)** -- GovernanceEngine decision/query/mutation APIs, DelegationBuilder, PactGovernedAgent
+- **[pact-kaizen-integration](pact-kaizen-integration.md)** -- PACT + Kaizen bridging pattern, EATP type convergence
+- **[pact-mcp-bridge](pact-mcp-bridge.md)** -- MCP tool governance (`mcp` feature), 6-step evaluation, NaN protection
 
-# MCP governance
-from kailash.trust.pact.mcp import (
-    McpGovernanceEnforcer, McpGovernanceMiddleware, McpAuditTrail,
-    McpToolPolicy, McpGovernanceConfig, McpActionContext,
-)
-```
+### Bindings and Patterns
 
-## TrustPostureLevel (Decision 007)
+- **[pact-python-binding](pact-python-binding.md)** -- PyO3 binding (21 types), address serde format, build/test
+- **[governance-patterns](governance-patterns.md)** -- Governance integration patterns
 
-Five canonical posture levels with autonomy gradient:
+## 16 User Flows
 
-| Canonical  | Autonomy | Ceiling      | Old Name (alias)   |
-| ---------- | -------- | ------------ | ------------------ |
-| PSEUDO     | 1        | PUBLIC       | PSEUDO_AGENT       |
-| TOOL       | 2        | RESTRICTED   | _(new, no old)_    |
-| SUPERVISED | 3        | CONFIDENTIAL | SHARED_PLANNING    |
-| DELEGATING | 4        | SECRET       | CONTINUOUS_INSIGHT |
-| AUTONOMOUS | 5        | TOP_SECRET   | DELEGATED          |
+| #   | Flow                | Entry Point                                     | Key Invariant                                      |
+| --- | ------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| 1   | Compile org         | `GovernanceEngine::new(org_def)`                | Grammar: D/T must be followed by R                 |
+| 2   | Access check        | `engine.check_access(role_id, item, posture)`   | 5-step fail-closed algorithm                       |
+| 3   | Posture ceiling     | Implicit in step 2                              | `effective = min(clearance, posture_ceiling)`      |
+| 4   | Action verification | `engine.verify_action(addr, action, ctx)`       | 4-zone gradient, worst-zone wins                   |
+| 5   | NEVER_DELEGATED     | Implicit in flow 4                              | 7 actions always HELD                              |
+| 6   | Bridge access       | Step 3e in flow 2                               | Bilateral vs unilateral directionality             |
+| 7   | Bridge approval     | `engine.request_bridge()` / `approve_bridge()`  | LCA approver, Pending->Approved gate               |
+| 8   | Frozen context      | `engine.get_context(addr, posture)`             | No `&mut self`, no Deserialize                     |
+| 9   | Python integration  | `from kailash import PactGovernanceEngine`      | 25+ types, thread-safe                             |
+| 10  | Role discovery      | `engine.list_roles()` / `get_node_by_role_id()` | All roles (not just heads), v3.4.1                 |
+| 11  | Address resolution  | `engine.resolve_role_id("D1-R1")`               | Resolves D/T/R address OR config ID, v3.4.1        |
+| 12  | Vacancy designation | `engine.set_vacancy_designation()`              | Acting occupant, 24h expiry, fail-closed           |
+| 13  | Auto-suspension     | `RoleConfig::auto_suspend_on_vacancy`           | BFS cascade, opt-in per-role                       |
+| 14  | LCA computation     | `Address::lowest_common_ancestor(a, b)`         | O(depth), grammar-validated                        |
+| 15  | Dimension scoping   | `DelegationRecord::dimension_scope`             | BTreeSet<DimensionName>, subset tightening         |
+| 16  | Nested departments  | `DepartmentConfig::departments` (v3.6.1)        | Recursive D-R-D-R, `compile_department()` recurses |
 
-Old names work as enum aliases (`TrustPostureLevel.PSEUDO_AGENT` resolves to `PSEUDO`). String deserialization of old values is handled by `_missing_()`.
+See the PACT governance flows documentation for detailed storyboards.
 
-## Rules
+## 4-Zone Gradient
 
-See `.claude/rules/pact-governance.md` for security invariants.
+| Zone         | `allowed()` | When                                     |
+| ------------ | ----------- | ---------------------------------------- |
+| AutoApproved | true        | Action within all limits                 |
+| Flagged      | true        | Action >= 80% of a limit                 |
+| Held         | false       | NEVER_DELEGATED action or unknown action |
+| Blocked      | false       | Action exceeds hard limit                |
+
+Worst zone across all 5 dimensions wins.
+
+## Store Backends
+
+| Backend                    | Feature  | Use Case                                      |
+| -------------------------- | -------- | --------------------------------------------- |
+| `MemoryEnvelopeStore` etc. | default  | In-process, bounded (10K FIFO), tests         |
+| `SqlitePactStore`          | `sqlite` | Persistent, auto-migration, file or in-memory |
+
+## Security Invariants
+
+- GovernanceContext: Serialize only (NO Deserialize -- anti-forgery)
+- FiniteF64: Rejects NaN/Inf at construction
+- `evaluate_financial`: checks `is_finite()` for transaction_amount AND daily_total
+- NEVER_DELEGATED_ACTIONS: 7 actions always HELD regardless of envelope
+- Default-deny: unregistered tools blocked, step 4 denies, missing envelopes block
+- Bounded stores: MAX_STORE_SIZE = 10,000 with FIFO eviction
+- Address: MAX_SEGMENTS = 100 (DoS prevention)
+- MCP bridge: default-deny, clearance-gated, financial-limited, NaN-protected

--- a/.claude/skills/29-pact/pact-kaizen-integration.md
+++ b/.claude/skills/29-pact/pact-kaizen-integration.md
@@ -1,271 +1,39 @@
----
-name: pact-kaizen-integration
-description: "Cross-package integration -- GovernanceEnvelopeAdapter, AuditChain, GradientEngine, YAML orgs"
----
+# PACT + Kaizen Integration
 
-# PACT-Kaizen Integration
+PACT governance and kailash-kaizen's trust module are independent but complementary layers. PACT provides organizational governance (who can do what within the org structure), while kaizen's trust module provides cryptographic trust (EATP chains, delegation, verification gradient).
 
-PACT governance integrates with Kaizen agent teams through adapters, audit chains, and YAML-based organization definitions.
+## Relationship
 
-## Wrapping a Kaizen Agent
+- **PACT** (`kailash-pact`): Organizational governance -- D/T/R addresses, knowledge clearance, operating envelopes, 5-step access, 4-zone gradient. No dependency on kaizen.
+- **Kaizen trust** (`kailash-kaizen::trust`): Cryptographic trust -- Ed25519 keys, CareChain, delegation chains, circuit breakers, shadow enforcers, lifecycle hooks. Depends on `eatp` crate.
+- **Shared type**: Both use `eatp::constraints::ConstraintEnvelope` / `Dimensions` for the 5-dimensional constraint model. PACT wraps these in its `RoleEnvelope`/`TaskEnvelope` layers.
 
-```python
-from pact.governance.engine import GovernanceEngine
-from pact.governance.agent import PactGovernedAgent, GovernanceBlockedError
-from pact.governance.config import TrustPostureLevel
+## Bridging Pattern (Application Code)
 
-# 1. Build governance engine from org definition
-engine = GovernanceEngine(org_definition)
+```rust
+use kailash_pact::engine::GovernanceEngine;
+use kailash_pact::agent::PactGovernedAgent;
+use kailash_kaizen::trust::agent::GovernedAgent;
 
-# 2. Wrap each Kaizen agent with governance
-governed_agent = PactGovernedAgent(
-    engine=engine,
-    role_address="D1-R1-T1-R1",     # Agent's position in org
-    posture=TrustPostureLevel.SUPERVISED,
-)
+// 1. PACT layer: organizational governance
+let pact_engine = GovernanceEngine::new(org_def)?;
+let mut pact_agent = PactGovernedAgent::new(pact_engine, "D1-R1-T1-R1", posture)?;
+pact_agent.register_tool("analyze", Some(5.0), None)?;
 
-# 3. Register the agent's tools
-governed_agent.register_tool("analyze", cost=5.0)
-governed_agent.register_tool("summarize", cost=2.0)
-governed_agent.register_tool("deploy", cost=100.0)
+// 2. Kaizen layer: cryptographic trust (wraps a BaseAgent)
+let governed = GovernedAgent::new(base_agent, trust_config).await?;
 
-# 4. Execute tools through governance
-try:
-    result = governed_agent.execute_tool(
-        "analyze",
-        _tool_fn=lambda: kaizen_agent.run_tool("analyze", data),
-    )
-except GovernanceBlockedError as e:
-    print(f"Blocked: {e.verdict.reason}")
+// 3. Compose: PACT verifies org constraints, then kaizen executes with trust
+let pact_result = pact_agent.execute_tool("analyze", || {
+    // Inside: kaizen's governed TAOD loop handles evidence + delegation
+    governed.run_governed(task).await
+})?;
 ```
 
-## GovernanceEnvelopeAdapter
+## Key Distinction
 
-Bridges PACT governance envelopes to trust-layer `ConstraintEnvelope` for backward compatibility with Kaizen's `ExecutionRuntime` and `GradientEngine`.
+`PactGovernedAgent` enforces envelope limits and access policies at the organizational level. `GovernedAgent` (kaizen) enforces cryptographic trust, evidence recording, and delegation chain validity at the protocol level. In production, both layers wrap the same underlying agent execution.
 
-```python
-from pact.governance.envelope_adapter import GovernanceEnvelopeAdapter, EnvelopeAdapterError
+## EATP Type Convergence
 
-adapter = GovernanceEnvelopeAdapter(engine=engine)
-
-# Convert governance envelope to trust-layer ConstraintEnvelope
-try:
-    trust_envelope = adapter.to_constraint_envelope(
-        role_address="D1-R1-T1-R1",
-        task_id="sprint-42",  # optional
-    )
-    # trust_envelope is a kailash.trust.plane.models.ConstraintEnvelope
-    # Usable with ExecutionRuntime and GradientEngine
-except EnvelopeAdapterError as e:
-    # Fail-closed: no fallback to legacy envelopes
-    print(f"Conversion failed: {e}")
-```
-
-**Field mapping:**
-
-| PACT (governance)                       | Trust-layer                      |
-| --------------------------------------- | -------------------------------- |
-| `financial.max_spend_usd`               | `financial.max_cost_per_session` |
-| `financial.requires_approval_above_usd` | `financial.max_cost_per_action`  |
-| `operational.allowed_actions`           | `operational.allowed_actions`    |
-| `data_access.read_paths`                | `data_access.read_paths`         |
-| `communication.allowed_channels`        | `communication.allowed_channels` |
-
-## AuditChain
-
-Thread-safe tamper-evident chain of audit anchors for governance decisions.
-
-```python
-from pact.governance.audit import AuditChain, AuditAnchor, PactAuditAction
-from pact.governance.config import VerificationLevel
-
-# Create audit chain
-chain = AuditChain(chain_id="acme-governance")
-
-# Append anchors (thread-safe, auto-sealed with SHA-256 hash chain)
-anchor = chain.append(
-    agent_id="analyst-1",
-    action="read_financial_data",
-    verification_level=VerificationLevel.AUTO_APPROVED,
-    envelope_id="env-analyst",
-    result="allowed",
-    metadata={"cost": 10.0, "resource": "q4-report"},
-)
-
-anchor.anchor_id        # "acme-governance-0"
-anchor.sequence         # 0
-anchor.content_hash     # SHA-256 hex digest
-anchor.previous_hash    # None (genesis) or previous anchor's hash
-anchor.is_sealed        # True
-anchor.verify_integrity()  # True
-
-# Query the chain
-chain.length                                    # int
-chain.latest                                    # AuditAnchor
-chain.filter_by_agent("analyst-1")              # [AuditAnchor, ...]
-chain.filter_by_level(VerificationLevel.BLOCKED)  # [AuditAnchor, ...]
-
-# Verify entire chain integrity
-is_valid, errors = chain.verify_chain_integrity()
-# (True, []) or (False, ["Anchor 3: content hash mismatch (tampered?)"])
-
-# Serialize/deserialize
-data = chain.to_dict()
-restored = AuditChain.from_dict(data)
-```
-
-**Bounded collection:** Chain has `max_anchors=10_000` by default. When capacity is reached, the oldest 10% is evicted.
-
-### Integrating with GovernanceEngine
-
-```python
-chain = AuditChain(chain_id="acme-governance")
-
-engine = GovernanceEngine(
-    org_definition,
-    audit_chain=chain,   # All decisions are automatically recorded
-)
-
-# Every verify_action(), grant_clearance(), set_role_envelope(), etc.
-# emits an anchor to the chain
-verdict = engine.verify_action("D1-R1-T1-R1", "deploy", {"cost": 500.0})
-
-# SQLite backend also has its own audit log with integrity verification
-engine = GovernanceEngine(
-    org_definition,
-    store_backend="sqlite",
-    store_url="/tmp/pact.db",
-)
-is_valid, error_msg = engine.verify_audit_integrity()
-```
-
-## GradientEngine
-
-Evaluates actions against constraint dimensions independently from the main engine. Useful for pre-flight checks or custom evaluation.
-
-```python
-from pact.governance.gradient import GradientEngine, EvaluationResult
-from pact.governance.config import (
-    VerificationGradientConfig,
-    GradientRuleConfig,
-    VerificationLevel,
-)
-
-# Configure gradient rules (first match wins)
-gradient = VerificationGradientConfig(
-    rules=[
-        GradientRuleConfig(
-            pattern="deploy*",
-            level=VerificationLevel.HELD,
-            reason="Deployments require human approval",
-        ),
-        GradientRuleConfig(
-            pattern="read*",
-            level=VerificationLevel.AUTO_APPROVED,
-            reason="Read operations are pre-approved",
-        ),
-    ],
-    default_level=VerificationLevel.HELD,
-)
-
-# Create engine with envelope and gradient
-gradient_engine = GradientEngine(config=envelope, gradient=gradient)
-
-# Evaluate an action
-result = gradient_engine.evaluate(
-    action="deploy_to_prod",
-    context={"cost_usd": 500.0, "channel": "internal"},
-)
-
-result.level           # VerificationLevel.HELD (matched "deploy*")
-result.all_satisfied   # True/False (all dimensions passed?)
-result.matched_rule    # "deploy*"
-result.action          # "deploy_to_prod"
-
-# Per-dimension results
-for dim in result.dimensions:
-    print(f"{dim.dimension.value}: {'PASS' if dim.satisfied else 'FAIL'} -- {dim.reason}")
-```
-
-## YAML Organization Definition
-
-Load org definitions from YAML for Kaizen agent team configuration.
-
-```python
-from pact.governance.yaml_loader import load_org_yaml, LoadedOrg
-
-loaded: LoadedOrg = load_org_yaml("org-config.yaml")
-loaded.org_definition   # OrgDefinition
-loaded.envelopes        # list[EnvelopeSpec]
-loaded.clearances       # list[ClearanceSpec]
-loaded.bridges          # list[BridgeSpec]
-loaded.ksps             # list[KspSpec]
-```
-
-Example YAML:
-
-```yaml
-org:
-  org_id: acme-ai-division
-  name: "Acme AI Division"
-  departments:
-    - department_id: engineering
-      name: Engineering
-      teams: [ml-team, infra-team]
-  teams:
-    - id: ml-team
-      name: ML Team
-      workspace: ml-workspace
-      team_lead: ml-lead
-      agents: [ml-lead, ml-analyst]
-  agents:
-    - id: ml-lead
-      name: ML Team Lead
-      role: team_lead
-      constraint_envelope: lead-envelope
-    - id: ml-analyst
-      name: ML Analyst
-      role: analyst
-      constraint_envelope: analyst-envelope
-  envelopes:
-    - id: lead-envelope
-      financial:
-        max_spend_usd: 1000.0
-      operational:
-        allowed_actions: [read, write, analyze, deploy, approve]
-    - id: analyst-envelope
-      financial:
-        max_spend_usd: 100.0
-      operational:
-        allowed_actions: [read, write, analyze]
-  workspaces:
-    - id: ml-workspace
-      path: /data/ml
-```
-
-## PactAuditAction Types
-
-10 governance action types recorded in audit anchors:
-
-| Action               | When Emitted                                 |
-| -------------------- | -------------------------------------------- |
-| `envelope_created`   | `set_role_envelope()`, `set_task_envelope()` |
-| `envelope_modified`  | Envelope update                              |
-| `clearance_granted`  | `grant_clearance()`                          |
-| `clearance_revoked`  | `revoke_clearance()`                         |
-| `barrier_enforced`   | Access denied                                |
-| `ksp_created`        | `create_ksp()`                               |
-| `ksp_revoked`        | KSP deactivation                             |
-| `bridge_established` | `create_bridge()`                            |
-| `bridge_revoked`     | Bridge deactivation                          |
-| `address_computed`   | Address compilation                          |
-
-## Cross-References
-
-- `pact-governance-engine.md` -- GovernanceEngine API
-- `pact-governed-agents.md` -- PactGovernedAgent wrapping pattern
-- `pact-envelopes.md` -- envelope model consumed by adapter
-- Source: `pact/governance/envelope_adapter.py`
-- Source: `pact/governance/audit.py`
-- Source: `pact/governance/gradient.py`
-- Source: `pact/governance/yaml_loader.py`
+PACT's `envelopes.rs` imports `eatp::constraints::{ConstraintEnvelope, Dimensions, FinancialConstraints, ...}` directly. The `intersect_dimensions()` function in PACT applies pass-through semantics (NULL=unconstrained, aligned with EATP) on top of the shared EATP types, ensuring the same constraint vocabulary and NULL semantics are used across both layers.

--- a/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
+++ b/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
@@ -16,7 +16,7 @@ Each worktree branches from the committed HEAD and applies ONE feature. Filter w
 
 ```bash
 for wt in .claude/worktrees/agent-*/; do
-    f="${wt}src/myapp/core/engine.py"
+    f="${wt}src/kailash/trust/pact/engine.py"
     [ -f "$f" ] || continue
     n1=$(grep -c "KnowledgeFilter" "$f")
     n2=$(grep -c "_envelope_cache" "$f")
@@ -31,8 +31,8 @@ done
 Each diff isolates one feature's additions without entanglement:
 
 ```bash
-git show HEAD:src/myapp/core/engine.py > /tmp/engine_head.py
-diff -u /tmp/engine_head.py .claude/worktrees/agent-XXX/src/myapp/core/engine.py > /tmp/n1.patch
+git show HEAD:src/kailash/trust/pact/engine.py > /tmp/engine_head.py
+diff -u /tmp/engine_head.py .claude/worktrees/agent-XXX/src/kailash/trust/pact/engine.py > /tmp/n1.patch
 ```
 
 ### 3. Delegate the merge to a specialist
@@ -69,7 +69,7 @@ Before merging a worktree branch, check if its merge-base is older than the targ
 
 ```bash
 # For each worktree about to merge, compare LOC of shared files
-TARGET_FILE="src/myapp/agents/base_agent.py"
+TARGET_FILE="packages/kailash-kaizen/src/kaizen/core/base_agent.py"
 for wt in .claude/worktrees/agent-*/; do
     wt_file="${wt}${TARGET_FILE}"
     [ -f "$wt_file" ] || continue

--- a/.claude/skills/34-kailash-ml/SKILL.md
+++ b/.claude/skills/34-kailash-ml/SKILL.md
@@ -1,327 +1,421 @@
----
-name: kailash-ml
-description: "Kailash ML — MANDATORY for ALL ML training/inference/feature work. 13 engines (FeatureStore, ModelRegistry, TrainingPipeline, DriftMonitor, AutoML, HyperparameterSearch, Ensemble, etc.), polars-native, ONNX serving, agent-augmented search. Use proactively when work touches feature stores, training pipelines, inference servers, drift detection, ensembles, or 'just a quick sklearn pipeline'. Raw sklearn, pytorch, numpy, pandas training loops BLOCKED."
----
+# kailash-ml — Classical ML Framework (Rust)
 
-# Kailash ML — Classical & Deep Learning Lifecycle
-
-Production ML lifecycle framework built on Kailash Core SDK — polars-native engines, schema-driven pipelines, agent-augmented AutoML, and cross-language ONNX serving.
-
-## Install Matrix
-
-```
-pip install kailash-ml            # Core: polars, numpy, scipy, sklearn, lightgbm, plotly, onnx
-pip install kailash-ml[dl]        # + PyTorch, Lightning, transformers, timm
-pip install kailash-ml[dl-gpu]    # + onnxruntime-gpu
-pip install kailash-ml[rl]        # + Stable-Baselines3, Gymnasium
-pip install kailash-ml[agents]    # + kailash-kaizen (agent integration)
-pip install kailash-ml[xgb]       # + XGBoost
-pip install kailash-ml[catboost]  # + CatBoost
-pip install kailash-ml[explain]   # + SHAP (model explainability)
-pip install kailash-ml[imbalance] # + imbalanced-learn (SMOTE, ADASYN)
-pip install kailash-ml[stats]     # + statsmodels
-pip install kailash-ml[full]      # Everything (CPU)
-pip install kailash-ml[all-gpu]   # Everything (GPU)
-```
-
-## 13 Engines (by Priority)
-
-| #   | Engine                | Priority | Purpose                                                            | Key Dependency                     |
-| --- | --------------------- | -------- | ------------------------------------------------------------------ | ---------------------------------- |
-| 1   | FeatureStore          | P0       | Polars-native feature versioning, point-in-time queries            | ConnectionManager                  |
-| 2   | ModelRegistry         | P0       | Model versioning (staging/shadow/production/archived), ONNX export | ConnectionManager, ArtifactStore   |
-| 3   | TrainingPipeline      | P0       | sklearn/LightGBM/Lightning training with FeatureSchema             | FeatureStore, ModelRegistry        |
-| 4   | InferenceServer       | P0       | REST serving via kailash-nexus, response caching, batch            | ModelRegistry, kailash-nexus       |
-| 5   | DriftMonitor          | P0       | KS/chi2/PSI/Jensen-Shannon drift detection, scheduled checks       | ConnectionManager                  |
-| 6   | ExperimentTracker     | P0       | MLflow-compatible run tracking, metric comparison, audit           | ConnectionManager                  |
-| 7   | HyperparameterSearch  | P1       | Grid/random/Bayesian/successive halving optimization               | TrainingPipeline                   |
-| 8   | AutoMLEngine          | P1       | Multi-family model search, optional agent augmentation             | HyperparameterSearch, FeatureStore |
-| 9   | EnsembleEngine        | P1       | Blend/stack/bag/boost ensemble creation                            | TrainingPipeline                   |
-| 10  | PreprocessingPipeline | P1       | Auto-setup from FeatureSchema, imputation, encoding                | FeatureSchema                      |
-| 11  | DataExplorer          | P2       | Statistical profiling, plotly visualization, comparison            | polars, plotly                     |
-| 12  | FeatureEngineer       | P2       | Auto-generation, selection, importance ranking                     | polars                             |
-| 13  | ModelExplainer        | P2       | SHAP-based global/local/dependence explanations                    | SHAP (requires [explain])          |
-
-**Additional modules**: OnnxBridge, MlflowFormatReader/Writer, MLDashboard (all lazy-loaded).
+20-crate workspace providing scikit-learn-equivalent algorithms with Rust performance. 90+ estimator types, 62 EstimatorRegistry entries, TransformerRegistry, rayon parallelism. All crates proprietary (`publish = false`).
 
 ## Quick Start
 
-### Feature Ingestion
+```rust
+use kailash_ml::core::estimator::Fit;
+use kailash_ml::core::fit_opts::FitOpts;
+use kailash_ml::linear::ols::LinearRegression;
+
+let lr = LinearRegression::default();
+let fitted = lr.fit(x.view(), y.view(), &FitOpts::default())?;
+let predictions = fitted.predict(x_test.view())?;
+let r2 = fitted.score(x_test.view(), y_test.view())?;
+```
+
+## Crate Layout
+
+```
+crates/
+  kailash-ml/                # Umbrella — re-exports all sub-crates + engine layer (MlEngine, ModelRegistry, ExperimentTracker, AutoMl)
+  kailash-ml-core/           # Traits, DataSet, FitOpts, MlError, RandomState, sampling, DynEstimator, EstimatorRegistry
+  kailash-ml-linalg/         # SVD/QR/eigendecomposition, distance/kernel functions, solvers (L-BFGS, SAGA, SGD, coord descent)
+  kailash-ml-preprocessing/  # StandardScaler, MinMaxScaler, OneHotEncoder, SimpleImputer, KNNImputer, IterativeImputer, Normalizer
+  kailash-ml-linear/         # OLS, Ridge, Lasso, ElasticNet, LogisticRegression, SGD, GLMs, Bayesian, Robust (17 registry entries)
+  kailash-ml-tree/           # CART splitter+criteria, DecisionTree (Regressor+Classifier)
+  kailash-ml-ensemble/       # RandomForest, ExtraTrees, Bagging, AdaBoost, Voting, Stacking, IsolationForest (13 entries)
+  kailash-ml-boost/          # GradientBoosting (Reg+Clf), HistGradientBoosting (Reg+Clf), DART, GOSS/EFB, monotone constraints
+  kailash-ml-svm/            # SMO solver (WSS-3), SVC/SVR, LinearSVC/LinearSVR, NuSVC/NuSVR, OneClassSVM, kernel cache
+  kailash-ml-neighbors/      # KD-tree, BallTree, KNeighbors (Clf+Reg), RadiusNeighbors (Clf+Reg), NearestCentroid
+  kailash-ml-cluster/        # KMeans, MiniBatchKMeans, DBSCAN, HDBSCAN, OPTICS, Birch, AgglomerativeClustering, AffinityPropagation, SpectralClustering, MeanShift
+  kailash-ml-decomposition/  # PCA, IncrementalPCA, TruncatedSVD, NMF, FactorAnalysis, FastICA, KernelPCA, t-SNE, LDA (topic), SparsePCA, DictionaryLearning, SelectKBest, RFE
+  kailash-ml-metrics/        # 60+ metrics: classification, regression, ranking (ROC/AUC), clustering, Scorer
+  kailash-ml-selection/      # KFold, StratifiedKFold, GroupKFold, TimeSeriesSplit, cross_val_score, GridSearchCV
+  kailash-ml-pipeline/       # Pipeline, ColumnTransformer, FeatureUnion
+  kailash-ml-misc/           # GaussianNB, MultinomialNB, BernoulliNB, LDA/QDA, GaussianProcess, MLP (Clf+Reg), CalibratedClassifierCV, IsotonicRegression, OneVsRest/OneVsOne, GaussianMixture, LabelPropagation/Spreading, BernoulliRBM, PLSRegression, CCA
+  kailash-ml-text/           # CountVectorizer, TfidfVectorizer, HashingVectorizer
+  kailash-ml-explorer/       # DataExplorer: profiling, alerts, HTML reports with scatter plots, KDE, Cramer's V
+  kailash-ml-nodes/          # 7 workflow nodes: EstimatorFitNode, PredictNode, MLTransformNode, CrossValidateNode, PipelineNode, MetricNode, ScoreNode
+  kailash-ml-python/         # PyO3 bindings: 126 pyclass types + 30 pyfunctions, module at `bindings/kailash-python/src/ml/mod.rs`
+```
+
+## Trait System (kailash-ml-core)
+
+```
+Layer 1 (Type-State):     Config --fit()--> FittedConfig (compile-time safety)
+Layer 2 (Object-Safe):    Box<dyn DynEstimator> / Box<dyn DynTransformer> (Pipeline, GridSearch)
+```
+
+| Trait             | Purpose                                             | Used By                                     |
+| ----------------- | --------------------------------------------------- | ------------------------------------------- |
+| `Fit`             | Supervised fitting: `fit(x, y, opts) -> Fitted`     | All regressors/classifiers                  |
+| `FitUnsupervised` | Unsupervised: `fit(x) -> Fitted`                    | KMeans, PCA, DBSCAN, NMF, GMM               |
+| `Predict`         | `predict(x) -> Array1`                              | All fitted models                           |
+| `PredictProba`    | `predict_proba(x) -> Array2`                        | Classifiers                                 |
+| `Transform`       | `transform(dataset) -> DataSet`                     | Preprocessors, PCA                          |
+| `FitTransform`    | Combined fit+transform                              | Preprocessors, KNNImputer, IterativeImputer |
+| `Score`           | `score(x, y) -> f64`                                | R2 (regression), accuracy (classification)  |
+| `BaseEstimator`   | `get_params/set_params/estimator_type`              | All algorithms                              |
+| `DynEstimator`    | Object-safe estimator (blanket impl from Fit+Clone) | GridSearchCV, cross_val_score               |
+| `DynTransformer`  | Object-safe transformer (blanket from FitTransform) | Pipeline steps                              |
+
+**Key invariant**: Every algorithm implementing `Fit` + `Predict` + `Clone` gets `DynEstimator` via blanket impl. IsolationForest and OneClassSVM implement `Fit` (wrapping `FitUnsupervised`, ignoring `y`) to enable DynEstimator blanket and EstimatorRegistry participation.
+
+## Engine Layer (kailash-ml umbrella) -- COMPLETE (10 modules)
+
+The engine module (`crates/kailash-ml/src/engine/`) provides high-level orchestration on top of the algorithm crates. All 10 modules are fully implemented.
+
+| Component           | Key Types                                                        | Purpose                                                                                         |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `MlEngine`          | `MlEngine`, `MlWorkflowBuilder`, `MlWorkflow`                    | Builder-configured environment: registry + tracker + fluent workflow API                        |
+| `ModelRegistry`     | `ModelRegistry`, `FileSystemRegistry`, `InMemoryRegistry`        | Version-controlled model storage with stage lifecycle (Dev->Staging->Prod->Archived)            |
+| `ExperimentTracker` | `ExperimentTracker`, `LocalTrackerBackend`                       | Training run telemetry: params, time-series metrics, SVG charts, JSON persistence               |
+| `AutoMl`            | `AutoMl`, `AutoMlConfig`, `TaskType`                             | Automated model selection with time budget + trial limits (`selection` feature)                 |
+| `InferenceServer`   | `InferenceServer`, `InferenceConfig`, `ModelInfo`                | TTL cache, latency percentiles (p50/p95/p99), ModelRegistry integration, DashMap-backed         |
+| `DriftMonitor`      | `DriftMonitor`, `DriftConfig`, `DriftReport`                     | PSI + KS two-sample test, prediction monitoring, bounded history, per-feature drift             |
+| `FeatureStore`      | `FeatureStore`, `FileSystemFeatureStore`, `InMemoryFeatureStore` | Versioned feature sets with lineage tracking, `FeatureStoreBackend` trait                       |
+| `OnnxBridge`        | `OnnxBridge`, `OnnxModel`, `OnnxGraph`                           | Linear + tree model export to ONNX-compatible JSON serialization                                |
+| `ModelVisualizer`   | `ModelVisualizer`, `ConfusionMatrix`, `RocCurve`                 | Confusion matrix, ROC/AUC, feature importance, classification report, learning curve, residuals |
+| `FeatureEngineer`   | `FeatureEngineer`, `FeatureEngineerBuilder`                      | Polynomial features, scalers (Standard/MinMax/Robust), encoders, feature selection              |
+
+```rust
+// MlEngine: fluent workflow API with auto-tracking
+let engine = MlEngine::builder()
+    .with_model_dir("/tmp/models")
+    .build()?;
+
+let result = engine.workflow()
+    .data(x_train.view(), y_train.view())
+    .grid_search("RandomForestClassifier", &param_grid)
+    .cross_validate(5)
+    .build_and_run()?;
+
+// InferenceServer: cached predictions with latency tracking
+let server = InferenceServer::new(InferenceConfig { ttl_secs: 300, ..Default::default() });
+server.register_model("rf-v1", model_artifact, engine.registry())?;
+let predictions = server.predict("rf-v1", &input)?;
+let metrics: InferenceMetricsSnapshot = server.metrics("rf-v1")?; // p50, p95, p99
+
+// DriftMonitor: detect data/prediction drift
+let monitor = DriftMonitor::new(DriftConfig::default());
+monitor.set_reference(reference_data.view())?;
+let report: DriftReport = monitor.check(production_data.view())?;
+// report.features contains per-feature PSI + KS p-value
+
+// FeatureStore: versioned feature management
+let store = FeatureStore::new(FileSystemFeatureStore::new("/tmp/features")?);
+store.register("user_features", feature_array.view(), metadata)?;
+let features = store.get("user_features", Some("v2"))?;
+
+// FeatureEngineer: preprocessing pipeline
+let eng = FeatureEngineer::builder()
+    .polynomial_features(2)
+    .scaler(ScalerType::Standard)
+    .select_k_best(10, SelectionMethod::FScore)
+    .build()?;
+let transformed = eng.fit_transform(x.view(), Some(y.view()))?;
+```
+
+## EstimatorRegistry (compile-time, inventory-based)
+
+62 estimators registered via `register_estimator!` macro across algorithm crates. Enables string-based lookup for workflow nodes and dynamic dispatch. See also TransformerRegistry (P3) for transformer-specific lookup.
+
+```rust
+let est = EstimatorRegistry::get("RandomForestClassifier")?;
+let est = EstimatorRegistry::get_with_params("Ridge", &params)?;
+let names = EstimatorRegistry::list();
+let classifiers = EstimatorRegistry::list_by_type(EstimatorType::Classifier);
+```
+
+## Feature Flags (kailash-ml umbrella)
+
+```toml
+[features]
+default = ["linear", "tree", "ensemble", "preprocessing", "metrics", "pipeline", "selection"]
+full = ["default", "boost", "svm", "neighbors", "cluster", "decomposition", "text", "misc", "explorer"]
+blas = ["kailash-ml-linalg/blas"]  # Optional BLAS acceleration
+```
+
+## Performance Patterns
+
+**Parallel (rayon):** RandomForest/ExtraTrees/Bagging training + prediction, KMeans n_init, cross_val_score folds, GridSearchCV params, ColumnTransformer columns, FeatureUnion, HistGB prediction, DBSCAN distances.
+
+**Vectorized:** KMeans distances (ndarray dot products, zero per-sample allocs), euclidean_distances via BLAS trick.
+
+**Algorithmic:** Randomized SVD for PCA (Halko 2011), HistGB histogram subtraction, L-BFGS two-loop recursion, WSS-3 SMO, Barnes-Hut t-SNE, Kahan compensated summation.
+
+**Memory:** HistGB BinnedDataset column-major u8 (8x less than f64), KD-tree leaf_size=30, BallTree for high-dimensional neighbors.
+
+## Pipeline Composition
+
+```rust
+use kailash_ml_preprocessing::scalers::StandardScaler;
+use kailash_ml_linear::logistic::LogisticRegression;
+use kailash_ml_pipeline::{Pipeline, Step};
+
+// Preprocessors implement FitTransform -> DynTransformer blanket impl
+// KNNImputer and IterativeImputer also implement FitTransform for Pipeline use
+let pipe = Pipeline::new(
+    vec![Step::transformer("scaler", Box::new(StandardScaler::default()))],
+    Some(Step::estimator("lr", Box::new(LogisticRegression::default()))),
+);
+```
+
+## Python Bindings (v3.12.0+)
+
+126 pyclass types + 10 pyfunctions in `bindings/kailash-python/src/ml.rs`. Feature-gated behind `ml` (default-enabled in kailash-enterprise wheel).
+
+**API**: sklearn-compatible — `fit(X, y)`, `predict(X)`, `score(X, y)`, `transform(X)`, `fit_transform(X, y)`, `get_params()`, `set_params(**kwargs)`. Data interchange via `numpy` arrays (`pyo3-numpy`).
+
+**Estimator patterns**: Two internal strategies —
+
+- `SupervisedState`: wraps `Box<dyn DynEstimator>` for all supervised models (regressors, classifiers, SVMs, ensembles). Uniform fit/predict/score.
+- Inline config+fitted: used for unsupervised models (KMeans, PCA, StandardScaler) that have their own fit paths.
+
+**Metric functions**: `accuracy_score`, `precision_score`, `recall_score`, `f1_score`, `r2_score`, `mean_squared_error`, `mean_absolute_error`.
+
+**Utility functions**: `list_estimators()`, `estimator_count()`, `data_profile(X)` (statistical profiling via kailash-ml-explorer).
 
 ```python
-from kailash.db.connection import ConnectionManager
-from kailash_ml import FeatureStore
-from kailash_ml.types import FeatureSchema, FeatureField
-import polars as pl
+from kailash.ml import LinearRegression, accuracy_score, data_profile
 
-conn = ConnectionManager("sqlite:///ml.db")
-await conn.initialize()
-
-schema = FeatureSchema(
-    name="user_churn",
-    features=[
-        FeatureField(name="age", dtype="float"),
-        FeatureField(name="tenure_months", dtype="float"),
-    ],
-    target=FeatureField(name="churned", dtype="int"),
-)
-
-fs = FeatureStore(conn, table_prefix="kml_feat_")
-await fs.initialize()
-
-df = pl.read_csv("data.csv")
-await fs.ingest("user_features", schema, df)
-
-# Point-in-time retrieval
-features = await fs.get_features("user_features", entity_ids=["u1", "u2"])
+lr = LinearRegression()
+lr.fit(X_train, y_train)
+preds = lr.predict(X_test)
+r2 = lr.score(X_test, y_test)
+print(lr.get_params())  # {"fit_intercept": True}
 ```
 
-### Training
+**Coverage**: All 14 sub-crates exposed — linear (17), tree (2), ensemble (13), boost (5), svm (8), neighbors (6), cluster (10), decomposition (13), preprocessing (7), misc (20+), text (3), pipeline (3), selection (5), metrics (7 functions). Explorer via `data_profile()`.
+
+## M11 Text Features (v3.12.2, `text` feature flag)
+
+6 vectorizers in `kailash-ml-text/`:
+
+| Vectorizer          | Purpose                                 | Sparse Output |
+| ------------------- | --------------------------------------- | ------------- |
+| `CountVectorizer`   | Token counts (bag-of-words)             | Yes           |
+| `TfidfTransformer`  | IDF weighting on count matrix           | Yes           |
+| `TfidfVectorizer`   | Count + IDF in one step                 | Yes           |
+| `HashingVectorizer` | Stateless hashing trick (no vocabulary) | Yes           |
+| `FeatureHasher`     | Hashes arbitrary feature dicts          | Yes           |
+| `DictVectorizer`    | Dict-of-features to sparse matrix       | Yes           |
+
+All implement `Fit` / `Transform` / `FitTransform` + `BaseEstimator`. Pipeline-compatible via `DynTransformer` blanket.
+
+```rust
+use kailash_ml_text::tfidf::TfidfVectorizer;
+
+let corpus = vec!["the cat sat", "the dog ran"];
+let vectorizer = TfidfVectorizer::default();
+let fitted = vectorizer.fit_transform(&corpus)?;
+// fitted: sparse CSR matrix, shape (2, vocab_size)
+```
+
+**Pipeline integration**: Chain vectorizers with classifiers in `Pipeline`. Integration tests use realistic multi-document corpora.
+
+## M13 Workflow Nodes (kailash-ml-nodes)
+
+7 workflow nodes in `crates/kailash-ml-nodes/src/nodes/` that integrate ML into the Kailash workflow engine. Generic dispatch by name -- one node type dispatches to any registered estimator/transformer/metric at runtime via `EstimatorRegistry` / `get_scorer()`. 32 tests.
+
+| Node                | Purpose                                              | Registry Dispatch                        |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------- |
+| `EstimatorFitNode`  | Fit any registered estimator by name                 | `EstimatorRegistry::get_with_params()`   |
+| `PredictNode`       | Predict using a fitted model from workflow context   | Via fitted model                         |
+| `MLTransformNode`   | Apply any transformer by name (scalers, encoders)    | `EstimatorRegistry` (transformer subset) |
+| `CrossValidateNode` | K-fold cross-validation with configurable scorer     | `EstimatorRegistry` + `get_scorer()`     |
+| `PipelineNode`      | Build and run multi-step Pipeline from config        | `EstimatorRegistry` per step             |
+| `MetricNode`        | Compute any metric by name on predictions vs targets | `get_scorer()`                           |
+| `ScoreNode`         | Score a fitted model using its built-in `.score()`   | Via fitted model                         |
+
+```rust
+// EstimatorFitNode dispatches to any registered estimator
+let node = EstimatorFitNode::from_config(&ValueMap::from([
+    ("estimator_name".into(), "RandomForestClassifier".into()),
+    ("n_estimators".into(), 100.into()),
+]));
+// At runtime: EstimatorRegistry::get_with_params("RandomForestClassifier", &params)
+```
+
+## M14 Python Bindings Restructure
+
+126 estimator PyO3 classes + 30 functions covering all algorithm families. Module restructured from single `ml.rs` to `ml/mod.rs` for maintainability.
+
+**Module layout:**
+
+- Rust: `bindings/kailash-python/src/ml/mod.rs`
+- Python subpackage: `bindings/kailash-python/python/kailash/ml/__init__.py` (explicit `__all__` re-exports)
+
+**Import pattern:**
 
 ```python
-from kailash_ml import TrainingPipeline, ModelRegistry, ModelSpec, EvalSpec
-from kailash_ml.engines import LocalFileArtifactStore
+# Correct — through the Python subpackage
+from kailash.ml import LinearRegression, RandomForestClassifier, accuracy_score
 
-registry = ModelRegistry(conn, artifact_store=LocalFileArtifactStore("./artifacts"))
-await registry.initialize()
-
-pipeline = TrainingPipeline(feature_store=fs, model_registry=registry)
-result = await pipeline.train(
-    schema=schema,
-    model_spec=ModelSpec(model_class="sklearn.ensemble.RandomForestClassifier"),
-    eval_spec=EvalSpec(metrics=["accuracy", "f1"]),
-)
+# Internal binding path (used by __init__.py, not end users)
+from kailash._kailash import PyLinearRegression  # NOT bare `from _kailash`
 ```
 
-### Drift Monitoring
+**Coverage by family:**
 
-```python
-from kailash_ml import DriftMonitor
+| Family        | Classes | Functions |
+| ------------- | ------- | --------- |
+| Linear        | 17      | --        |
+| Tree          | 2       | --        |
+| Ensemble      | 13      | --        |
+| Boost         | 5       | --        |
+| SVM           | 8       | --        |
+| Neighbors     | 6       | --        |
+| Cluster       | 10      | --        |
+| Decomposition | 13      | --        |
+| Preprocessing | 7       | --        |
+| Misc          | 20+     | --        |
+| Text          | 3       | --        |
+| Pipeline      | 3       | --        |
+| Selection     | 5       | --        |
+| Metrics       | --      | 7         |
+| Explorer      | --      | 1         |
+| Utilities     | --      | 2         |
 
-monitor = DriftMonitor(conn)
-await monitor.initialize()
-await monitor.set_reference("model_v1", reference_df)
-report = await monitor.check_drift("model_v1", current_df)
-# report.overall_drift, report.feature_results, report.recommendations
+## M15 Benchmarks
+
+43 Criterion benchmarks in `crates/kailash-ml/benches/ml_bench.rs` across 16 groups. Used for regression detection and performance characterization.
+
+**Benchmark groups:** linear, tree, ensemble, gradient boosting, SVM, KNN, clustering, PCA, preprocessing, pipeline, scaling (plus additional algorithmic groups).
+
+**Synthetic data helpers** (in the bench file):
+
+- `make_classification(n_samples, n_features)` -- generates labeled classification data
+- `make_regression(n_samples, n_features)` -- generates continuous regression data
+- `classification_target(n_samples)` -- generates binary class labels
+
+```bash
+# Run all ML benchmarks
+cargo bench -p kailash-ml
+
+# Run a single group
+cargo bench -p kailash-ml -- linear
 ```
 
-### Model Explainability (requires `[explain]`)
+## M16 API Documentation
 
-```python
-from kailash_ml import ModelExplainer
+`#![warn(missing_docs)]` enforced on all 20 ML crates via dual mechanism:
 
-explainer = ModelExplainer(model=fitted_model, X=train_df, feature_names=schema.feature_names)
-global_report = explainer.explain_global(max_display=10)
-local_report = explainer.explain_local(X=test_df, index=0)
-fig = explainer.to_plotly("summary")  # "summary", "beeswarm", "dependence"
-```
+1. `Cargo.toml` `[lints.rust]` section: `missing_docs = "warn"`
+2. `lib.rs` attribute: `#![warn(missing_docs)]`
 
-### AutoML with Agent Augmentation
+Enriched module-level documentation for P0 crates:
 
-```python
-from kailash_ml import AutoMLEngine
-from kailash_ml.engines.automl_engine import AutoMLConfig
+- **kailash-ml-core** -- trait hierarchy, EstimatorRegistry, DataSet, FitOpts, error types
+- **kailash-ml** (umbrella) -- engine layer overview, feature flags, re-export index
+- **kailash-ml-preprocessing** -- scaler/encoder/imputer contracts, pipeline integration
+- **kailash-ml-linear** -- regression/classification families, solver selection, regularization
+- **kailash-ml-tree** -- CART splitter, criteria (gini/entropy/mse), pruning
+- **kailash-ml-linalg** -- SVD/QR/eigendecomposition, solver inventory, BLAS acceleration
 
-config = AutoMLConfig(
-    task_type="classification",
-    metric_to_optimize="f1",
-    search_strategy="bayesian",
-    search_n_trials=50,
-    agent=True,            # LLM augmentation (requires kailash-ml[agents])
-    auto_approve=False,    # Human approval gate
-    max_llm_cost_usd=5.0,
-)
-engine = AutoMLEngine(feature_store=fs, model_registry=registry, config=config)
-result = await engine.run(schema=schema, data=df)
-```
+## P2-P4 Registry Integration (v3.13.0)
 
-### Model Registry Lifecycle
+Post-milestone phases that added remaining algorithms and completed registry coverage across all algorithm families.
 
-```python
-# Stage transitions: staging → shadow → production → archived
-await registry.promote("model_v1", version_id, target_stage="production")
+### New Algorithms
 
-# Valid transitions:
-# staging    → shadow, production, archived
-# shadow     → production, archived, staging
-# production → archived, shadow
-# archived   → staging
-```
+- **PLSCanonical** (canonical PLS, symmetric deflation) in kailash-ml-misc — completes the cross-decomposition family alongside PLSRegression and CCA
 
-### Preprocessing Pipeline
+### Registry Integration
 
-```python
-from kailash_ml.engines import PreprocessingPipeline
+Algorithms that existed but lacked `register_estimator!` / `register_transformer!` macro invocations were integrated into the compile-time registries:
 
-pipeline = PreprocessingPipeline()
-result = pipeline.setup(
-    data=df, target="churned",
-    normalize=True, normalize_method="zscore",       # zscore, minmax, robust, maxabs
-    imputation="knn", impute_n_neighbors=5,           # knn, iterative, default
-    remove_multicollinearity=True, multicollinearity_threshold=0.9,
-    fix_imbalance=True, imbalance_method="smote",     # smote, adasyn ([imbalance])
-)
-```
+**EstimatorRegistry (`register_estimator!`):**
 
-### Nested Runs & Auto-Logging
+| Family              | Algorithms                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| Clustering          | SpectralClustering, MeanShift, MiniBatchKMeans, OPTICS, Birch, AffinityPropagation (Fit+Predict) |
+| Semi-supervised     | LabelPropagation, LabelSpreading                                                                 |
+| Cross-decomposition | PLSRegression, PLSCanonical, CCA                                                                 |
 
-```python
-from kailash_ml import ExperimentTracker
+**TransformerRegistry (`register_transformer!`):**
 
-tracker = ExperimentTracker(conn)
-await tracker.initialize()
+| Family        | Algorithms                                                           |
+| ------------- | -------------------------------------------------------------------- |
+| Kernel approx | RBFSampler, Nystroem                                                 |
+| Decomposition | SparsePCA, DictionaryLearning                                        |
+| Pipeline      | BernoulliRBM (FitTransform + DynTransformer)                         |
+| Text          | CountVectorizer, TfidfVectorizer, HashingVectorizer (DynTransformer) |
 
-async with tracker.run("hyperopt-sweep") as parent:
-    for params in param_grid:
-        async with tracker.run("trial", parent_run_id=parent.run_id) as child:
-            await child.log_params(params)
-```
+**Note:** TfidfTransformer implements FitTransform but is not registered as a standalone transformer — it is used internally by TfidfVectorizer.
 
-## Decision Tree: kailash-ml vs kailash-align vs kailash-kaizen
+### New Infrastructure
 
-| You Want To...                        | Use                                                 |
-| ------------------------------------- | --------------------------------------------------- |
-| Train sklearn/LightGBM/XGBoost models | **kailash-ml**                                      |
-| Manage feature pipelines              | **kailash-ml**                                      |
-| Monitor model drift                   | **kailash-ml**                                      |
-| Export models to ONNX                 | **kailash-ml**                                      |
-| Fine-tune an LLM (LoRA, DPO, RLHF)    | **kailash-align**                                   |
-| Serve a fine-tuned LLM via Ollama     | **kailash-align**                                   |
-| Build an AI agent with tools          | **kailash-kaizen**                                  |
-| Add agent intelligence to ML engines  | **kailash-ml[agents]** (uses Kaizen under the hood) |
-| Train RL policies (Gymnasium)         | **kailash-ml[rl]**                                  |
+- **TransformerRegistry** + `register_transformer!` macro in kailash-ml-core — parallel to EstimatorRegistry, enables string-based lookup for transformer types in workflow nodes and dynamic dispatch
+- **`ParamDistribution::sample_n()`** — batch sampling for hyperparameter search (avoids per-sample overhead in GridSearchCV/RandomSearchCV)
 
-## Polars-Native Rule (ABSOLUTE)
+### New Visualization
 
-Every engine accepts and returns `polars.DataFrame`. Conversion to numpy/pandas/LightGBM Dataset happens ONLY in `interop.py` at sklearn/framework boundaries.
+- **`scatter_plot_svg()`** standalone function in kailash-ml-explorer — generates scatter plot SVGs without requiring a full DataExplorer instance
+- **`training_curve_svg()` / `training_curves_svg()`** on ExperimentTracker — render training metric time-series as SVG charts directly from tracked experiment data
 
-```python
-# DO: Work in polars throughout
-df = pl.read_csv("data.csv")
-await fs.ingest("features", schema, df)
+## Milestone Status
 
-# DO NOT: Convert to pandas first
-df_pd = pd.read_csv("data.csv")  # WRONG — polars is the native format
-```
+All milestones M0-M16 and phases P1-P4 complete:
 
-## Interop Conversion Table
+| Milestone | Description                          | Status   |
+| --------- | ------------------------------------ | -------- |
+| M0        | Core traits + DataSet                | Complete |
+| M1        | Linear models                        | Complete |
+| M2        | Tree models                          | Complete |
+| M3        | Ensemble models                      | Complete |
+| M4        | Gradient boosting                    | Complete |
+| M5        | SVM                                  | Complete |
+| M6        | Neighbors                            | Complete |
+| M7        | Clustering + Decomposition           | Complete |
+| M8        | Metrics + Selection + Pipeline       | Complete |
+| M9        | Miscellaneous algorithms             | Complete |
+| M10       | Engine layer (10 modules)            | Complete |
+| M11       | Text features                        | Complete |
+| M12       | Explorer (DataExplorer)              | Complete |
+| M13       | Workflow nodes (7 nodes, 32 tests)   | Complete |
+| M14       | Python bindings (126 classes)        | Complete |
+| M15       | Benchmarks (43 Criterion benches)    | Complete |
+| M16       | API docs (missing_docs on 20 crates) | Complete |
+| P1        | Clippy + test hardening              | Complete |
+| P2        | Estimator registry completion        | Complete |
+| P3        | Transformer registry + new infra     | Complete |
+| P4        | Visualization + PLSCanonical         | Complete |
 
-All conversions live in `interop.py`. Import from there only.
+## Dependencies
 
-| Function                   | From             | To                                   | Use When                    |
-| -------------------------- | ---------------- | ------------------------------------ | --------------------------- |
-| `to_sklearn_input()`       | polars DataFrame | (X: ndarray, y: ndarray, info: dict) | Training with sklearn       |
-| `from_sklearn_output()`    | ndarray          | polars DataFrame                     | Converting predictions back |
-| `to_lgb_dataset()`         | polars DataFrame | lightgbm.Dataset                     | Training with LightGBM      |
-| `to_hf_dataset()`          | polars DataFrame | datasets.Dataset                     | HuggingFace integration     |
-| `polars_to_arrow()`        | polars DataFrame | pyarrow.Table                        | Arrow IPC / Parquet         |
-| `from_arrow()`             | pyarrow.Table    | polars DataFrame                     | Ingesting Arrow data        |
-| `to_pandas()`              | polars DataFrame | pandas.DataFrame                     | Legacy pandas interop       |
-| `from_pandas()`            | pandas.DataFrame | polars DataFrame                     | Ingesting pandas data       |
-| `polars_to_dict_records()` | polars DataFrame | list[dict]                           | JSON serialization          |
-| `dict_records_to_polars()` | list[dict]       | polars DataFrame                     | JSON deserialization        |
+Core: `ndarray` 0.16, `sprs` 0.11, `rayon` 1.10, `rand` 0.8/`rand_chacha` 0.3, `serde`, `bincode`, `inventory`. No external ML libraries -- all algorithms implemented from scratch.
 
-## Architecture
+## Gotchas
 
-```
-kailash-ml/
-  engines/
-    _shared.py              ← Numeric dtypes, model class validation
-    _feature_sql.py         ← ALL raw SQL (zero SQL in engine files)
-    _guardrails.py          ← AgentGuardrailMixin (5 mandatory guardrails)
-    feature_store.py        ← FeatureStore (ConnectionManager, polars-native)
-    model_registry.py       ← ModelRegistry (lifecycle, SHA256 integrity)
-    training_pipeline.py    ← TrainingPipeline (schema-driven)
-    inference_server.py     ← InferenceServer (Nexus, ONNX, caching)
-    drift_monitor.py        ← DriftMonitor (KS/chi2/PSI/JS)
-    model_explainer.py      ← ModelExplainer (SHAP, [explain])
-    experiment_tracker.py   ← MLflow-compatible tracking (nested runs)
-    hyperparameter_search.py ← Grid/random/bayesian/successive halving
-    automl_engine.py        ← Agent-infused AutoML
-    ensemble.py             ← Blend/stack/bag/boost
-    preprocessing.py        ← Auto-setup from FeatureSchema
-  agents/                   ← 6 Kaizen agents ([agents])
-    tools.py                ← Dumb data endpoints (LLM-first)
-  rl/                       ← RLTrainer, EnvironmentRegistry, PolicyRegistry
-  interop.py                ← SOLE conversion point
-  bridge/                   ← OnnxBridge (export + verification)
-```
+- `FitOpts` carries `sample_weight`, `class_weight`, `eval_set` -- always pass even if default. `RandomState` is a separate type in `kailash_ml_core::random`
+- `DataSet` is an enum (`Dense`/`Sparse`) carrying data matrix with optional feature names -- `Target` is a separate enum for supervised labels
+- `MlError::NotFitted` if you call fitted methods on unfitted state (runtime check for dyn dispatch)
+- Sparse matrices (`sprs::CsMat`) supported in core but not all algorithms accept them yet
+- Histogram subtraction in HistGB requires sorted bin indices -- do not shuffle binned data
+- `rand` 0.8 API (NOT 0.9+): use `thread_rng()`, not `rng()`
+- When `faer` is in scope, provide explicit type annotations to avoid inference ambiguity
 
-### Internal Module Guide
+## Key Files
 
-| Module            | Purpose                                                                                   | When to Touch                          |
-| ----------------- | ----------------------------------------------------------------------------------------- | -------------------------------------- |
-| `_shared.py`      | NUMERIC_DTYPES, ALLOWED_MODEL_PREFIXES, validate_model_class(), compute_metrics_by_name() | Adding new model frameworks or metrics |
-| `_feature_sql.py` | ALL raw SQL for FeatureStore (zero SQL elsewhere)                                         | Any FeatureStore schema/query change   |
-| `_guardrails.py`  | AgentGuardrailMixin (cost budget, audit trail, approval gate)                             | Adding agent integration to any engine |
-| `interop.py`      | SOLE conversion point: polars ↔ sklearn/lgb/arrow/pandas/hf                               | Adding new framework interop           |
-
-## 6 ML Agents (kailash-ml[agents])
-
-Agents require both `agent=True` AND the agents extra installed. All follow LLM-first rule.
-
-| Agent                      | Purpose                        |
-| -------------------------- | ------------------------------ |
-| DataScientistAgent         | Data profiling recommendations |
-| FeatureEngineerAgent       | Feature generation guidance    |
-| ModelSelectorAgent         | Model selection reasoning      |
-| ExperimentInterpreterAgent | Trial result analysis          |
-| DriftAnalystAgent          | Drift report interpretation    |
-| RetrainingDecisionAgent    | Retrain/rollback decisions     |
-
-See [ml-agent-guardrails](ml-agent-guardrails.md) for the 5 mandatory guardrails.
-
-## RL Module (kailash-ml[rl])
-
-```python
-from kailash_ml.rl import RLTrainer, EnvironmentRegistry, PolicyRegistry
-
-env_reg = EnvironmentRegistry()
-env_reg.register("CartPole-v1")
-
-trainer = RLTrainer(env_registry=env_reg, policy_registry=PolicyRegistry())
-result = await trainer.train(env_id="CartPole-v1", algorithm="PPO", total_timesteps=100_000)
-```
-
-## Security Checklist
-
-When writing or reviewing kailash-ml engine code, verify:
-
-- [ ] **SQL identifiers**: All interpolated identifiers pass through `_validate_identifier()` (from `kailash.db.dialect`)
-- [ ] **SQL types**: Column types validated via `_validate_sql_type()` allowlist (INTEGER, REAL, TEXT, BLOB, NUMERIC)
-- [ ] **SQL placement**: Zero raw SQL outside `_feature_sql.py` — all queries go through that module
-- [ ] **Model classes**: Dynamic model imports validated via `validate_model_class()` against ALLOWED_MODEL_PREFIXES (`sklearn.`, `lightgbm.`, `xgboost.`, `catboost.`, `kailash_ml.`, `torch.`, `lightning.`)
-- [ ] **Financial fields**: `math.isfinite()` on all cost/budget fields (NaN/Inf bypass comparisons)
-- [ ] **Table prefix**: Regex-validated in constructor (`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-- [ ] **Bounded collections**: Audit trails, cost logs, trial history use `deque(maxlen=N)`
-- [ ] **Agent guardrails**: Engines with agent integration inherit `AgentGuardrailMixin` (cost budget + approval gate)
-- [ ] **Interop boundary**: Conversions happen ONLY in `interop.py`, nowhere else
-
-## Skill Files
-
-- [ml-feature-pipelines](ml-feature-pipelines.md) — FeatureStore, polars-only engineering, schema-driven ingestion
-- [ml-model-registry](ml-model-registry.md) — ModelRegistry CRUD, lifecycle stages, MLflow compatibility
-- [ml-training-pipeline](ml-training-pipeline.md) — TrainingPipeline, hyperparameter search, experiment tracking
-- [ml-inference-server](ml-inference-server.md) — InferenceServer, Nexus exposure, ONNX serving, batch inference
-- [ml-agent-guardrails](ml-agent-guardrails.md) — 5 mandatory guardrails, AutoML, agent integration
-- [ml-onnx-export](ml-onnx-export.md) — PyTorch/sklearn to ONNX, verification, cross-language serving
-- [ml-drift-monitoring](ml-drift-monitoring.md) — DriftMonitor, statistical tests, alert thresholds, retraining triggers
-
-## Critical Rules
-
-- All engines are polars-native — no pandas/numpy in pipeline code
-- sklearn interop only at boundary via `interop.py`
-- FeatureStore uses ConnectionManager, not Express (needs window functions)
-- Zero raw SQL outside `_feature_sql.py`
-- Agent-augmented engines require double opt-in (`agent=True` + extras installed)
-- All agents follow LLM-first rule — tools are dumb data endpoints
-
-## Related Skills
-
-- [01-core-sdk](../01-core-sdk/SKILL.md) — Core workflow patterns
-- [02-dataflow](../02-dataflow/SKILL.md) — Database integration (ConnectionManager)
-- [03-nexus](../03-nexus/SKILL.md) — Multi-channel deployment (InferenceServer)
-- [04-kaizen](../04-kaizen/SKILL.md) — AI agent framework (ML agents)
-- [35-kailash-align](../35-kailash-align/SKILL.md) — LLM fine-tuning and alignment
-</content>
-</invoke>
+- Trait definitions + EstimatorRegistry: `crates/kailash-ml-core/src/estimator.rs`
+- DataSet type: `crates/kailash-ml-core/src/dataset.rs`
+- Engine module index: `crates/kailash-ml/src/engine/mod.rs`
+- Engine (MlEngine + MlWorkflowBuilder): `crates/kailash-ml/src/engine/builder.rs`
+- ModelRegistry (stage lifecycle): `crates/kailash-ml/src/engine/registry.rs`
+- ExperimentTracker (JSON persistence + SVG): `crates/kailash-ml/src/engine/tracker.rs`
+- AutoMl (time budget + trials): `crates/kailash-ml/src/engine/automl.rs`
+- InferenceServer (TTL cache + latency): `crates/kailash-ml/src/engine/inference.rs`
+- DriftMonitor (PSI + KS test): `crates/kailash-ml/src/engine/drift.rs`
+- FeatureStore (versioning + lineage): `crates/kailash-ml/src/engine/feature_store.rs`
+- OnnxBridge (linear + tree export): `crates/kailash-ml/src/engine/onnx.rs`
+- ModelVisualizer (confusion, ROC, etc.): `crates/kailash-ml/src/engine/visualizer.rs`
+- FeatureEngineer (polynomial, scalers): `crates/kailash-ml/src/engine/feature_eng.rs`
+- Workflow nodes: `crates/kailash-ml-nodes/src/nodes/` (estimator_fit, predict, transform, cross_validate, pipeline, metric, score)
+- Python bindings: `bindings/kailash-python/src/ml/mod.rs` (126 classes + 30 functions)
+- Python subpackage: `bindings/kailash-python/python/kailash/ml/__init__.py` (re-exports with `__all__`)
+- Benchmarks: `crates/kailash-ml/benches/ml_bench.rs` (43 Criterion benchmarks, 16 groups)
+- Solvers: `crates/kailash-ml-linalg/src/solvers.rs` (L-BFGS, Newton-CG, SAGA, SGD, coord descent)
+- Randomized SVD: `crates/kailash-ml-linalg/src/extmath.rs`

--- a/.claude/skills/spec-compliance/SKILL.md
+++ b/.claude/skills/spec-compliance/SKILL.md
@@ -190,6 +190,30 @@ Save to `workspaces/<project>/.spec-coverage-v2.md` (the `-v2` suffix prevents c
 3. No row says "exists: yes" — that is a banned phrase. Rows must show the literal command and its actual output count.
 4. Every CRITICAL/HIGH row has been fixed and re-verified, not deferred.
 
+## Spec Coverage Audit Cadence
+
+A single R0 grep pass is insufficient. Experience has proven this:
+R0 may find and fix a vulnerability at 2 call sites, but a follow-up
+R1 grep audit can find the same unprotected pattern at 5 additional
+sites that R0 missed because they used a slightly different variable
+name (e.g., `parsed.password` vs `result.password`).
+
+**Protocol after the first round of fixes:**
+
+1. Run the original grep pattern against the full codebase, not
+   just the files you touched in R0.
+2. Expand the grep to cover variant spellings (e.g., `parsed.password`,
+   `result.password`, `url_parts.password`, `unquote(.*password`).
+3. For each new match, verify the fix is present. Zero-match on
+   the expanded grep = confidence the pattern is fully addressed.
+4. Document the grep commands in the spec-coverage table so the
+   next round can re-run them.
+
+This "grep-for-pattern after R0" step catches drift between call
+sites that look different but share the same vulnerability. Without
+it, the audit converges on the sites it found first and misses the
+sites that use different variable names for the same concept.
+
 ## Anti-Patterns
 
 **BLOCKED audit behaviors:**

--- a/.coc-sync-marker
+++ b/.coc-sync-marker
@@ -1,14 +1,9 @@
-{
-  "synced_at": "2026-04-07T14:30:00Z",
-  "source": "loom/",
-  "target": "kailash-coc-claude-rs",
-  "variant": "rs",
-  "upstream_version": "3.10.0",
-  "template_version": "2.5.0",
-  "files": [
-    "variants/rs/rules/build-speed.md",
-    "variants/rs/commands/build.md",
-    "pyproject.toml",
-    ".claude/VERSION"
-  ]
-}
+synced_at: "2026-04-13T00:00:00+08:00"
+source: loom/
+target: kailash-coc-claude-rs
+gate1: reviewed (4 changes classified as variant-rs)
+gate2: completed
+files_updated: 20
+files_added: 5
+content_adapted: 1 (03-creating-components.md)
+variants_placed: independence.md (new), security.md, constant-time-comparison-rs.md, fail-closed-defaults-rs.md


### PR DESCRIPTION
## Summary
- Gate 1: 4 variant-rs changes from kailash-rs v3.15.2 codify (Aegis identity, security fixes)
- Gate 2: 5 new global skills, 17 updated files
- NEW: Aegis two-track identity variant (independence.md replaces TF Foundation global)
- FIX: ApiKeyConfig::validate_key function name, DataClassification enum, cross-binding gap docs
- VERSION: 2.7.0 → 2.8.0, upstream build_version 3.15.1→3.15.2

## Test plan
- [ ] Verify independence.md correctly overrides global for rs context
- [ ] Spot-check security skill corrections match BUILD repo source

🤖 Generated with [Claude Code](https://claude.com/claude-code)