### PR TITLE
chore(settings): enforce high effort + disable adaptive thinking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Kailash COC Claude (Rust-backed bindings) - Claude Code hooks configuration",
+  "effortLevel": "high",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Summary
- Add `effortLevel: "high"` to project settings.json
- Add `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"` env var
- Prevents adaptive thinking from skipping reasoning on rule-heavy turns

## Test plan
- [x] Settings-only change, no code impact
- [x] Verified JSON syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)