### PR TITLE
feat(coc): sync loom 2.8.7 — BP-041..047 codify-completion + ServiceClient binding skills

### DIFF
--- a/.claude/.coc-sync-marker
+++ b/.claude/.coc-sync-marker
@@ -1,8 +1,15 @@
-last_sync: 2026-04-11T16:00:00Z
-source: loom
-version: 2.8.0
-build_sdk_version: 3.12.1
-files_updated: 3
-files_new: 0
-files_preserved: true
-gate1_proposal: "fix(security): resolve all convergence red team gaps (PR #322)"
+last_synced: "2026-04-15T04:30:00Z"
+loom_version: "2.8.7"
+sync_direction: "loom → kailash-coc-claude-rs USE template (Gate 2)"
+scope: "2.8.7 codify-completion artifacts + ServiceClient binding skills + ffi-specialist first-time placement"
+files_new:
+  - .claude/skills/12-testing-strategies/impossibility-surface.md
+  - .claude/skills/06-python-bindings/typed-exception-hierarchy.md
+  - .claude/skills/06-python-bindings/layered-truncation.md
+  - .claude/skills/18-security-patterns/header-validation-at-construction.md
+  - .claude/agents/ffi-specialist.md
+files_updated:
+  - .claude/rules/testing.md (Delegating Primitives section added)
+  - .claude/agents/frameworks/nexus-specialist.md (ServiceClient Python binding section added)
+files_unchanged:
+  - .claude/rules/independence.md (already identical to variant)

--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -6,9 +6,9 @@
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "2.8.3",
+    "version": "2.8.7",
     "build_version": "3.15.2",
-    "synced_at": "2026-04-14T00:00:00+08:00",
+    "synced_at": "2026-04-15T04:30:00Z",
     "sdk_packages": {
       "kailash-enterprise": "3.15.2"
     }
@@ -85,9 +85,9 @@
     {
       "version": "2.8.0",
       "date": "2026-04-13",
-      "summary": "Sync kailash-rs 3.15.2 codify \u2014 Aegis identity variant (independence.md), security function name fixes (ApiKeyConfig::validate_key), DataClassification enum fix, cross-binding gap documentation. 5 new global skills, 4 updated variant files.",
+      "summary": "Sync kailash-rs 3.15.2 codify \u2014 (REVERTED 2026-04-15) kailash-rs-as-Aegis identity variant (independence.md) — misidentification, see 2.8.6 entry. Also: security function name fixes (ApiKeyConfig::validate_key), DataClassification enum fix, cross-binding gap documentation. 5 new global skills, 4 updated variant files.",
       "changes": [
-        "NEW VARIANT: rules/independence.md \u2014 Aegis two-track identity (replaces TF Foundation global for rs target). Origin: session 064a874b.",
+        "(REVERTED 2026-04-15) NEW VARIANT: rules/independence.md \u2014 introduced kailash-rs-as-Aegis identity framing; reverted in 2.8.6 because kailash-rs is the proprietary Kailash Rust SDK, not Aegis (Aegis is a separate downstream PACT-implementation by Integrum Global). Origin: session 064a874b.",
         "UPDATED VARIANT: rules/security.md \u2014 validate_token_against_list \u2192 ApiKeyConfig::validate_key.",
         "UPDATED VARIANT: skills/18-security-patterns/constant-time-comparison-rs.md \u2014 function name, hash-then-compare invariant, line references.",
         "UPDATED VARIANT: skills/18-security-patterns/fail-closed-defaults-rs.md \u2014 ClassificationLevel \u2192 DataClassification, cross-binding gap warning, enum disambiguation.",

--- a/.claude/agents/ffi-specialist.md
+++ b/.claude/agents/ffi-specialist.md
@@ -1,0 +1,284 @@
+---
+name: ffi-specialist
+description: FFI and language binding specialist. Use for PyO3, napi-rs, wasm-bindgen, C ABI, CGo, and JNA integration.
+tools: Read, Write, Edit, Bash, Grep, Glob, Task
+model: opus
+---
+
+# FFI & Language Binding Specialist
+
+You are a specialist in foreign function interfaces and language bindings for the Kailash Rust project. Your expertise covers safe FFI design, binding generation, memory safety across language boundaries, and cross-language testing.
+
+## Primary Responsibilities
+
+1. **C ABI Design** (kailash-capi) - Stable C interface for all language bindings
+2. **Python Bindings** (kailash-python) - PyO3 integration with zero-copy
+3. **Node.js Bindings** (kailash-node) - napi-rs with native async
+4. **WASM Bindings** (kailash-wasm) - wasm-bindgen for browser/edge
+5. **Go Bindings** (ffi/kailash-go) - CGo via kailash-capi, JSON data exchange
+6. **Java Bindings** (ffi/kailash-java) - JNA via kailash-capi, Gson marshaling
+7. **Memory Safety** - Ensure no leaks, use-after-free, or data races across boundaries
+
+## Binding Architecture
+
+```
+                    kailash-core (Rust)
+                         |
+                    kailash-capi (C ABI, 22 modules)
+                    /    |    \       \
+              PyO3  napi-rs  wasm  CGo / JNA
+              (Python) (Node) (Browser) (Go / Java)
+```
+
+### kailash-capi Modules
+
+The C ABI surface lives in `crates/kailash-capi/src/`. Key modules:
+
+| Module             | Surface                                                                       |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `lib.rs`           | Re-exports, version check                                                     |
+| `builder.rs`       | WorkflowBuilder new/add_node/connect/build/free                               |
+| `execution.rs`     | Runtime new/execute/free, result accessors                                    |
+| `checkpoint.rs`    | CheckpointStore memory/sqlite new/free, runtime attach/resume/find_incomplete |
+| `dataflow.rs`      | DataFlow new/free, express CRUD, model definition                             |
+| `nexus.rs`         | NexusApp/NexusConfig lifecycle                                                |
+| `enterprise.rs`    | RBAC, audit, multi-tenancy                                                    |
+| `kaizen_llm.rs`    | Agent/LlmClient lifecycle                                                     |
+| `pact.rs`          | Governance engine, envelope operations                                        |
+| `trust_plane.rs`   | Trust project, constraint enforcement                                         |
+| `l3.rs`            | L3 autonomy types                                                             |
+| `orchestration.rs` | Saga, task queue                                                              |
+| `streaming.rs`     | Event streaming                                                               |
+| `error.rs`         | Last-error thread-local, `kailash_last_error_message()`                       |
+
+All modules follow: opaque `*mut T` handle, `_new()` constructor, method functions taking handle as first arg, `_free()` destructor, JSON string exchange for complex data.
+
+### kailash-capi Patterns
+
+```rust
+/// Opaque handle for cross-language use
+#[repr(C)]
+pub struct KailashWorkflow {
+    _opaque: [u8; 0],
+}
+
+/// Create — caller must call _free when done
+#[no_mangle]
+pub extern "C" fn kailash_workflow_builder_new() -> *mut KailashWorkflowBuilder {
+    Box::into_raw(Box::new(WorkflowBuilder::new()))
+}
+
+/// Free — null-safe
+#[no_mangle]
+pub unsafe extern "C" fn kailash_workflow_builder_free(ptr: *mut KailashWorkflowBuilder) {
+    if !ptr.is_null() { drop(Box::from_raw(ptr)); }
+}
+
+/// Error codes
+#[repr(C)]
+pub enum KailashResult { Ok = 0, ErrInvalidArgument = 1, ErrBuildFailed = 2,
+    ErrExecutionFailed = 3, ErrNullPointer = 4 }
+```
+
+### Go Bindings (ffi/kailash-go/)
+
+14 source files, 8,695 LOC. CGo wrapper over kailash-capi.
+
+**Build prerequisite**: `cargo build -p kailash-capi --all-features` (the Makefile handles this).
+
+**Pattern**: Go struct wraps an opaque C pointer. Constructor calls `C.kailash_*_new()`, methods call `C.kailash_*_method()`, `Close()`/`Free()` calls `C.kailash_*_free()`. A `runtime.SetFinalizer` safety net guards against leaked handles.
+
+**JSON data exchange**: Go marshals structs to JSON via `encoding/json`, passes `C.CString` to C, receives JSON `*C.char` back, unmarshals. All C strings freed via `C.kailash_string_free()`.
+
+**Error handling**: Check C return code; on failure call `C.kailash_last_error_message()`, wrap in Go `error`.
+
+```go
+// Checkpoint example — lifecycle pattern
+store := kailash.CheckpointStoreMemory()   // C.kailash_checkpoint_store_memory_new()
+defer store.Free()                          // C.kailash_checkpoint_store_free()
+rt.SetCheckpointStore(store)               // consumes handle; Free() becomes no-op
+runs, _ := rt.FindIncompleteRuns()         // JSON round-trip
+```
+
+**Ownership transfer**: `SetCheckpointStore` consumes the store handle (C side frees the outer pointer). The Go wrapper marks `consumed = true`; subsequent `Free()` calls are safe no-ops.
+
+### Java Bindings (ffi/kailash-java/)
+
+27 main classes, 4,995 LOC. Uses **JNA** (`net.java.dev.jna`), NOT raw JNI.
+
+**Pattern**: `KailashLibrary.java` declares all C functions as a JNA `Library` interface. High-level wrapper classes hold a `Pointer` handle, delegate to `KailashLibrary.INSTANCE.kailash_*()`, and implement `AutoCloseable` for try-with-resources.
+
+**JSON data exchange**: Gson marshaling to/from JSON strings. JNA auto-converts `String` to `const char*`.
+
+**Error handling**: Check int return code from C; on non-zero call `kailash_last_error_message()`, throw `KailashException`.
+
+```java
+// Checkpoint example — AutoCloseable lifecycle
+try (CheckpointStore store = CheckpointStore.sqlite("/tmp/cp.db");
+     Runtime rt = new Runtime(registry)) {
+    rt.setCheckpointStore(store);  // consumes handle
+    rt.execute(workflow, Map.of());
+}  // store.close() is safe no-op after consumption
+```
+
+**Consumed-handle guard**: Same pattern as Go. `consumed` flag prevents double-free and blocks re-attachment to a second runtime.
+
+### PyO3 Patterns (kailash-python)
+
+```rust
+#[pyclass]
+struct PyWorkflowBuilder {
+    inner: Option<WorkflowBuilder>,  // Option for move semantics
+}
+
+#[pymethods]
+impl PyWorkflowBuilder {
+    #[new]
+    fn new() -> Self { Self { inner: Some(WorkflowBuilder::new()) } }
+
+    fn build(&mut self) -> PyResult<PyWorkflow> {
+        let builder = self.inner.take()
+            .ok_or_else(|| PyRuntimeError::new_err("Builder already consumed"))?;
+        let workflow = builder.build().map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(PyWorkflow { inner: workflow })
+    }
+}
+
+// Zero-copy string sharing via Arc<str>
+fn value_to_python(py: Python<'_>, value: &Value) -> PyObject {
+    match value {
+        Value::String(s) => s.as_ref().into_py(py),
+        Value::Bytes(b) => PyBytes::new(py, b).into(),
+        // ...
+    }
+}
+```
+
+### napi-rs Patterns (kailash-node)
+
+```rust
+#[napi]
+pub struct JsWorkflowBuilder { inner: Option<WorkflowBuilder> }
+
+#[napi]
+impl JsWorkflowBuilder {
+    #[napi(constructor)]
+    pub fn new() -> Self { Self { inner: Some(WorkflowBuilder::new()) } }
+
+    #[napi]
+    pub async fn execute(&self, workflow: &JsWorkflow) -> Result<JsExecutionResult> {
+        // Native async — returns JS Promise
+    }
+}
+```
+
+### wasm-bindgen Patterns (kailash-wasm)
+
+```rust
+#[wasm_bindgen]
+pub struct WasmWorkflowBuilder { inner: Option<WorkflowBuilder> }
+
+#[wasm_bindgen]
+impl WasmWorkflowBuilder {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self { Self { inner: Some(WorkflowBuilder::new()) } }
+}
+```
+
+## Critical Safety Rules
+
+### Memory Safety
+
+- All C API functions document safety requirements
+- Opaque pointers used for cross-language handles
+- Null pointer checks on all FFI entry points
+- No dangling references across language boundaries
+- RAII patterns for automatic cleanup (Go finalizers, Java AutoCloseable)
+- Consumed-handle guards prevent double-free on ownership transfer
+
+### Data Conversion
+
+- Zero-copy where possible (Arc<str> -> Python str view)
+- Buffer protocol for binary data (Bytes -> Python bytes)
+- JSON interop for complex types (Go/Java via kailash-capi)
+- Error codes for C API, exceptions for Python/Node/Java, Go `error` values
+
+### Thread Safety
+
+- All exported types are Send + Sync
+- GIL management for Python (release GIL during long operations)
+- Async support: Python asyncio, Node.js Promise, WASM Future
+- Go/Java: C ABI calls are inherently thread-safe (Rust side synchronized)
+
+### ABI Stability
+
+- C ABI uses `#[repr(C)]` for all exported structs
+- Semantic versioning for C header compatibility
+- No Rust-specific types in C API (use opaque pointers)
+- Version check function in C API
+
+## Testing Strategy
+
+### Unit Tests (per binding)
+
+```rust
+#[cfg(test)]
+mod tests {
+    // Test conversion functions, error handling, null safety
+}
+```
+
+### Integration Tests (cross-language)
+
+```python
+# Python
+import kailash
+builder = kailash.WorkflowBuilder()
+builder.add_node("Echo", "echo1", {"message": "hello"})
+workflow = builder.build()
+runtime = kailash.Runtime()
+results, run_id = runtime.execute(workflow)
+assert results["echo1"]["output"] == "hello"
+```
+
+```go
+// Go — see ffi/kailash-go/*_test.go (4 test files, 139-node assertion suite)
+store := kailash.CheckpointStoreMemory()
+defer store.Free()
+// ...
+```
+
+```java
+// Java — see ffi/kailash-java/src/test/java/com/kailash/
+try (Runtime rt = new Runtime(registry)) { /* ... */ }
+```
+
+## When to Use This Agent
+
+- Designing or modifying the C ABI (kailash-capi)
+- Building or debugging language bindings (PyO3, napi-rs, wasm-bindgen, CGo, JNA)
+- Memory safety review for FFI code
+- Cross-language testing strategies
+- Performance optimization at language boundaries
+- ABI stability and versioning decisions
+- Adding new capi modules (follow checkpoint.rs as the template for opaque-handle + JSON-exchange)
+
+### Stacked PR Lesson
+
+When binding work spans multiple PRs stacked on feature branches, merging the base PR and deleting its branch auto-closes the stacked PR. The stacked PR must be recreated targeting `main`. Plan for this when structuring multi-PR binding work.
+
+## Related Agents
+
+- **rust-architect**: For crate-level architecture decisions
+- **testing-specialist**: For cross-language test infrastructure
+- **security-reviewer**: For FFI safety review (unsafe blocks)
+- **release-specialist**: For binding package distribution
+- **cargo-specialist**: For feature flags and cross-compilation
+
+## Reference Documentation
+
+- `specs/bindings.md` - Cross-binding parity spec and API surface
+- `specs/cross-sdk-parity.md` - EATP D6 semantic parity requirements
+- `workspaces/core/01-analysis/05-ffi-strategy.md` - FFI design decisions
+- `workspaces/core/02-plans/04-phase3-language-bindings.md` - Binding implementation plan
+- `workspaces/core/03-user-flows/` - Per-language user experience flows

--- a/.claude/agents/frameworks/nexus-specialist.md
+++ b/.claude/agents/frameworks/nexus-specialist.md
@@ -103,27 +103,77 @@ Nexus struct
 
 ### Additional Types (v3.11.0+)
 
-| Type               | Module      | Purpose                                               |
-| ------------------ | ----------- | ----------------------------------------------------- |
-| `SessionConfig`    | `session`   | Cookie name, TTL, secure flag, same-site policy       |
-| `WsBroadcaster`    | `websocket` | Broadcast messages to all connected WebSocket clients |
-| `WsMessage`        | `websocket` | Text or binary WebSocket message payload              |
-| `McpAuthenticator` | `mcp::auth` | API key + bearer token auth for MCP SSE transport     |
+| Type               | Module           | Purpose                                                                     |
+| ------------------ | ---------------- | --------------------------------------------------------------------------- |
+| `SessionConfig`    | `session`        | Cookie name, TTL, secure flag, same-site policy                             |
+| `WsBroadcaster`    | `websocket`      | Broadcast messages to all connected WebSocket clients                       |
+| `WsMessage`        | `websocket`      | Text or binary WebSocket message payload                                    |
+| `McpAuthenticator` | `mcp::auth`      | API key + bearer token auth for MCP SSE transport                           |
+| `ServiceClient`    | `service_client` | Typed S2S HTTP client with SSRF guard, allowlist, header validation (#400)  |
+| `HttpClient`       | `http_client`    | Lower-level HTTP client primitive — SSRF + DNS rebind + allowlist (#399)    |
 
-```rust
-// Session with custom config
-use kailash_nexus::session::{InMemorySessionStore, SessionConfig};
-let config = SessionConfig::new().with_cookie_name("my_session").with_ttl(3600);
-nexus.with_session_store(Arc::new(InMemorySessionStore::new()), config);
+```python
+# Python binding: session, websocket, MCP auth (consumed via kailash-enterprise wheel)
+import kailash
 
-// WebSocket broadcasting
-use kailash_nexus::websocket::{WsBroadcaster, WsHandlerFn};
-let broadcaster = WsBroadcaster::new();
-nexus.websocket("/ws", ws_handler, broadcaster.clone());
+# Session config (sync Python wrapper around the Rust SessionConfig)
+session_cfg = kailash.SessionConfig(cookie_name="my_session", ttl_seconds=3600)
+```
 
-// MCP authentication
-use kailash_nexus::mcp::auth::{McpAuthConfig, McpAuthenticator};
-let auth = McpAuthenticator::new(McpAuthConfig { api_keys: vec!["key".into()], ..Default::default() });
+### ServiceClient — Typed S2S HTTP With Eager Validation (v3.16.1)
+
+`ServiceClient` is the canonical type for service-to-service HTTP calls inside a Nexus deployment. It validates URLs, headers, and bearer tokens at construction time, applies an SSRF guard against private/loopback IPs *before* the allowlist check, and exposes a typed exception hierarchy (6 subclasses) so Python callers can `except` discrete failure modes without parsing exception messages.
+
+```python
+import kailash
+
+# Construction-time validation: bad URL, bad header, or bad token raises immediately.
+try:
+    client = kailash.ServiceClient(
+        base_url="https://api.example.com/v1",
+        allowed_hosts=["api.example.com"],
+        timeout_secs=10.0,
+        bearer_token="eyJhbGc...",                   # validated, CRLF rejected
+        headers={
+            "X-Request-Id": "req-abc-123",           # validated
+            "X-Tenant": "tenant-acme",               # validated
+        },
+    )
+except kailash.ServiceClientInvalidHeaderError as e:
+    log.error("client construction rejected", error=str(e))
+    raise
+
+# Typed call: returns parsed dict, raises ServiceClientHttpStatusError on non-2xx.
+try:
+    user = client.get("/users/42")
+except kailash.ServiceClientHttpStatusError as e:
+    return None  # treat 404 as "no user"
+except kailash.ServiceClientDeserializeError as e:
+    log.error("backend returned malformed json", error=str(e))
+    raise
+except kailash.ServiceClientError:
+    raise        # any other failure from the subsystem
+
+# Raw call: returns {"status": int, "headers": dict, "body": str}, no status check.
+resp = client.get_raw("/health")
+if resp["status"] == 200:
+    print(json.loads(resp["body"]))
+```
+
+**Key invariants enforced by the type:**
+
+1. **SSRF guard runs before allowlist.** Loopback (`127.0.0.0/8`), private (`10/8`, `172.16/12`, `192.168/16`), link-local (`169.254/16`), and cloud metadata hosts (`metadata.google.internal`, `metadata.internal`) are blocked unconditionally. `allowed_hosts` cannot bypass the SSRF check — it only adds an additional filter for public hosts.
+2. **Header validation at construction.** `try_with_header` (Rust) / `__init__` (Python) validates every header name + value through `reqwest::header::HeaderName::try_from` / `HeaderValue::try_from`. CRLF, NUL, and non-ASCII bytes are rejected before the builder returns.
+3. **Bearer token routes through header validator.** `with_bearer_token` is fallible (returns `Result<Self, _>` in Rust; raises in Python `__init__`) and delegates to `try_with_header` — a CRLF-injected token fails at construction, not on first request.
+4. **Error bodies are layer-truncated.** Rust forensic logs keep ~4KB; Python exception messages are tightened to ~512 bytes via `truncate_py_error_body`. See `skills/06-python-bindings/layered-truncation.md`.
+5. **Typed exception hierarchy.** Six PyO3 subclasses of `ServiceClientError`: `ServiceClientHttpError`, `ServiceClientHttpStatusError`, `ServiceClientSerializeError`, `ServiceClientDeserializeError`, `ServiceClientInvalidPathError`, `ServiceClientInvalidHeaderError`. See `skills/06-python-bindings/typed-exception-hierarchy.md`.
+6. **Delegating primitive pairs need direct tests.** `get`/`get_raw`, `post`/`post_raw`, `put`/`put_raw`, `delete`/`delete_raw` — each variant has its own direct binding test. See `rules/testing.md` § Delegating Primitives Need Direct Coverage.
+
+**Test placement:** Python binding tests cannot exercise happy-path roundtrips because the SSRF guard blocks loopback before the allowlist runs (wiremock binds to 127.0.0.1). Happy-path coverage lives in the Rust wiremock suite at `crates/kailash-nexus/src/service_client.rs`; the Python tests cover error paths, eager validation, exception class distinctness, and SSRF rejection. See `skills/12-testing-strategies/impossibility-surface.md` for the documented-impossibility pattern.
+
+```python
+# Other Additional Types (session, WebSocket, MCP auth) — shown in the table above.
+# Their Python binding shapes follow the same kwargs-at-construction pattern as ServiceClient.
 ```
 
 ## Framework Selection

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -128,6 +128,70 @@ def test_workflow_execution():
     assert result["results"] is not None
 ```
 
+## Delegating Primitives Need Direct Coverage
+
+When a binding-layer class exposes paired variants that delegate to a shared core (e.g. `get` / `get_raw`, `post` / `post_raw`, `put` / `put_raw`, `delete` / `delete_raw`), each variant MUST have at least one test that calls it directly through the Python or Ruby binding — not a test that calls only one variant and reaches the other by delegation.
+
+This is a narrow rule about delegating primitive pairs. It is NOT a universal "every binding method has a direct test" mandate.
+
+### MUST: One Direct Test Per Variant Through The Binding
+
+```python
+# DO — one test per variant, called through the binding
+import kailash
+
+def test_service_client_get_typed_returns_dict(client):
+    """Direct exercise of the typed .get() Python binding method."""
+    user = client.get("/users/42")
+    assert isinstance(user, dict)
+    assert user["name"] == "Alice"
+
+def test_service_client_get_raw_returns_response_dict(client):
+    """Direct exercise of the raw .get_raw() Python binding method."""
+    resp = client.get_raw("/users/42")
+    assert isinstance(resp, dict)
+    assert resp["status"] == 200
+    assert "Alice" in resp["body"]
+
+# DO NOT — exercise only the typed variant and trust delegation
+def test_service_client_get_works(client):
+    """Only calls client.get(); never touches client.get_raw()."""
+    user = client.get("/users/42")
+    assert user["name"] == "Alice"
+# A refactor that changes get_raw's error mapping ships a silent regression
+# because the binding test never exercises that PyO3/Magnus boundary.
+```
+
+**Why:** Binding-layer paired variants cross the FFI boundary independently — a refactor that changes the typed variant's PyO3 conversion while leaving the raw variant alone ships a silent FFI regression. Tests that only exercise one variant cannot catch this because the failure mode is *across* the binding boundary, not in the shared Rust core.
+
+**BLOCKED rationalizations:**
+
+- "The typed variant calls the raw variant internally"
+- "Both variants share the same Rust execute() core"
+- "Integration tests at the Rust layer catch this"
+- "PyO3 wrapping is mechanical, it can't drift"
+
+### MUST: Mechanical Enforcement Via Grep
+
+`/redteam` MUST grep the binding test directory for direct call sites of each known raw variant and report any pair where one side has zero matches.
+
+```bash
+# DO — check each binding-exposed variant has a direct test in YOUR project's
+# test directory. Adjust TEST_DIR for your layout (the default `tests/` works
+# for most kailash-enterprise consumer projects).
+TEST_DIR="${TEST_DIR:-tests}"
+for variant in get_raw post_raw put_raw delete_raw; do
+  count=$(grep -rln "client\.$variant(" "$TEST_DIR" | wc -l)
+  if [ "$count" -eq 0 ]; then
+    echo "MISSING: no test calls client.$variant() through the Python binding"
+  fi
+done
+```
+
+**Why:** Mechanical grep at audit time catches the regression before it reaches a downstream consumer. Manual "I think I tested both" is not auditable across PyO3/Magnus binding refactors.
+
+Origin: BP-046 (kailash-rs ServiceClient binding test coverage, 2026-04-14, commit `d3a14a73`). The Rust `put_raw` and `delete_raw` had wiremock coverage; the Python binding equivalents at `bindings/kailash-python/tests/test_service_client.py` had no direct exercise — every test went through the typed `.put()` / `.delete()` variants. Fixed by adding direct binding-layer tests for each raw variant. The pattern applies to every binding pair that wraps a Rust delegating-primitive.
+
 ## Rules
 
 - Test-first development for new features

--- a/.claude/skills/06-python-bindings/layered-truncation.md
+++ b/.claude/skills/06-python-bindings/layered-truncation.md
@@ -1,0 +1,186 @@
+---
+name: layered-truncation
+description: "Use two truncation boundaries — forensic-sized body (~4KB) for Rust logs, tightly truncated body (~512B) for Python exception traceback. Use when wrapping any Rust error type whose body field can carry arbitrary remote content."
+priority: HIGH
+tags: [pyo3, python-binding, error-handling, observability, traceback]
+paths:
+  - "bindings/kailash-python/**"
+  - "bindings/kailash-ruby/**"
+---
+
+# Layered Truncation For PyO3 Error Bodies
+
+When a Rust error type carries a body field (HTTP response body, file content, command output, deserialization input), that body can be arbitrarily large. The Rust layer wants the *full* body for forensic logging and incident analysis. The Python binding layer wants the body *short* because it ends up inside an exception message that gets formatted into a traceback that gets logged, alerted, and displayed in stack traces — and a 4KB body inside a Python `__str__` produces 400-line traceback output that drowns the actual error signal.
+
+The right answer is **two truncation boundaries**:
+
+1. **Forensic boundary** at the Rust layer (typically ~4KB) — keeps enough body to debug the actual remote response, lives in Rust logs only
+2. **User-facing boundary** at the binding layer (typically ~512B) — fits inside an exception message without flooding tracebacks, lives in Python exception strings only
+
+Both boundaries are constants. Both have a single helper. Both are character-boundary-safe (never truncates mid-codepoint).
+
+## The Pattern
+
+### Step 1: Two Constants, Two Helpers
+
+The Rust crate declares its forensic constant and helper in the source file that produces the error. The PyO3 wrapper declares its tighter constant and a separate helper in the binding file. Do NOT share a single helper between layers — they have different audiences.
+
+```rust
+// crates/kailash-nexus/src/service_client.rs
+const MAX_ERROR_BODY_BYTES: usize = 4096;
+
+fn truncate_body(body: &str) -> String {
+    if body.len() <= MAX_ERROR_BODY_BYTES {
+        return body.to_owned();
+    }
+    let mut cut = MAX_ERROR_BODY_BYTES;
+    while cut > 0 && !body.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let truncated_bytes = body.len() - cut;
+    format!("{}... [truncated {} bytes]", &body[..cut], truncated_bytes)
+}
+```
+
+```rust
+// bindings/kailash-python/src/nexus.rs
+const PY_SERVICE_CLIENT_ERROR_BODY_BYTES: usize = 512;
+
+fn truncate_py_error_body(body: &str) -> String {
+    if body.len() <= PY_SERVICE_CLIENT_ERROR_BODY_BYTES {
+        return body.to_owned();
+    }
+    let mut cut = PY_SERVICE_CLIENT_ERROR_BODY_BYTES;
+    while cut > 0 && !body.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let truncated_bytes = body.len() - cut;
+    format!("{}... [truncated {} bytes]", &body[..cut], truncated_bytes)
+}
+```
+
+### Step 2: Apply The Helper At The PyErr Conversion Site
+
+The PyO3 → PyErr conversion function (see `typed-exception-hierarchy.md`) MUST call `truncate_py_error_body` on every body field before formatting it into the exception message. The Rust layer keeps the original body untouched in its logs.
+
+```rust
+fn service_client_err_to_pyerr(err: ServiceClientError) -> PyErr {
+    match &err {
+        E::HttpStatus { status, body } => {
+            let body_short = truncate_py_error_body(body);   // 512-byte ceiling for Python
+            ServiceClientHttpStatusError::new_err(format!(
+                "http_status status={status} body={body_short}"
+            ))
+        },
+        E::DeserializeResponse { status, body, error } => {
+            let body_short = truncate_py_error_body(body);   // same ceiling
+            ServiceClientDeserializeError::new_err(format!(
+                "deserialize_response status={status} error={error} body={body_short}"
+            ))
+        },
+        // other variants without body fields...
+    }
+}
+```
+
+The `body` field stored inside `ServiceClientError` itself remains the Rust-side `truncate_body` result (~4KB) — that's what gets logged via `tracing::warn!(?err)` for forensics. Only the *Python exception message* gets the tighter 512-byte version.
+
+### Step 3: What Python Sees
+
+Before the layered truncation pattern, a Python user catching a `ServiceClientHttpStatusError` from a server returning a 4KB error page would see:
+
+```
+ServiceClientHttpStatusError: http_status status=500 body=<!doctype html><html><head><title>...
+[400 lines of HTML elided in this snippet for brevity]
+...</html>
+```
+
+After:
+
+```
+ServiceClientHttpStatusError: http_status status=500 body=<!doctype html><html><head><title>Internal Server Error</title></head><body>... [truncated 3584 bytes]
+```
+
+Same forensic data is still in the Rust logs (visible to operators); the Python user's traceback is now ~5 lines instead of ~410.
+
+## DO / DO NOT
+
+```rust
+// DO — two layered helpers, one constant per layer
+const PY_SERVICE_CLIENT_ERROR_BODY_BYTES: usize = 512;
+
+fn truncate_py_error_body(body: &str) -> String { ... }
+
+// In the conversion function:
+let body_short = truncate_py_error_body(body);
+SomeError::new_err(format!("... body={body_short}"))
+
+// DO NOT — share the Rust forensic helper at the binding layer
+let body_short = truncate_body(body);             // BLOCKED — 4KB body in Python traceback
+SomeError::new_err(format!("... body={body_short}"))
+
+// DO NOT — no truncation, format raw body
+SomeError::new_err(format!("... body={body}"))    // BLOCKED — unbounded traceback
+```
+
+## MUST Rules
+
+### 1. Truncation Helpers Are Character-Boundary-Safe
+
+Every truncation helper MUST walk back from the byte limit to the nearest UTF-8 character boundary before slicing. Truncating mid-codepoint produces invalid UTF-8 and panics on `String::from_utf8` later in the pipeline.
+
+```rust
+// DO — walk back to char boundary
+let mut cut = LIMIT;
+while cut > 0 && !body.is_char_boundary(cut) {
+    cut -= 1;
+}
+let truncated = &body[..cut];
+
+// DO NOT — naive slice
+let truncated = &body[..LIMIT];   // panics on multi-byte char at LIMIT
+```
+
+**Why:** `&str[..n]` panics if `n` is not a character boundary. A response body containing a multi-byte UTF-8 character at the limit will crash the conversion function; the binding then panics across the FFI boundary which produces an uncatchable Python error.
+
+### 2. Always Report The Number Of Bytes Truncated
+
+The truncation helper MUST append `... [truncated N bytes]` (or equivalent) so the Python user knows how much was discarded. Silent truncation hides the size of the original body.
+
+```rust
+// DO — explicit truncation marker
+format!("{}... [truncated {} bytes]", &body[..cut], body.len() - cut)
+
+// DO NOT — silent truncation
+format!("{}", &body[..cut])
+```
+
+**Why:** Without the marker, a user looking at a 510-byte body cannot tell whether the response was ~510 bytes or 5MB. The marker is the only signal that distinguishes "small body" from "huge body, mostly hidden".
+
+### 3. Layer-Specific Constants, Not A Single Shared Constant
+
+The Rust forensic limit and the Python user-facing limit MUST be separate constants. Sharing a single `MAX_ERROR_BODY_BYTES` across layers couples the two contracts and forces one to compromise for the other.
+
+**Why:** Forensic logs need enough body to reconstruct the remote response (~4KB minimum for an HTML error page). Python tracebacks need to fit inside alerting payloads and stack-trace dumps (~512 bytes maximum). The two constraints are incompatible; trying to satisfy both with one number satisfies neither.
+
+## MUST NOT
+
+- Truncate the body INSIDE the Rust error variant before storing it
+
+**Why:** That would lose the forensic data permanently. The Rust error must keep the larger body; only the *PyErr message* gets the tighter version.
+
+- Use `.chars().take(N).collect()` instead of byte-based truncation
+
+**Why:** Slow (O(N) walk) and produces a string of N *characters* rather than N *bytes*, making the actual byte limit unpredictable for log-aggregator field-size limits.
+
+- Skip the truncation helper for "small bodies that probably fit"
+
+**Why:** "Probably fits" is exactly the assumption that breaks the first time a server returns a 50KB JSON error response. The helper is cheap and unconditional.
+
+## Related Skills
+
+- `skills/06-python-bindings/typed-exception-hierarchy.md` — the conversion function that calls `truncate_py_error_body` is documented in that skill; this skill covers the truncation half of the pattern
+- `skills/18-security-patterns/header-validation-at-construction.md` — the `InvalidHeader` variant returns a short error string that does NOT need truncation, so the helper is not called for that variant
+- `rules/observability.md` — broader logging rules; layered truncation is the binding-layer corollary of "structured log fields, not f-string interpolation"
+
+Origin: BP-043 (kailash-rs ServiceClient Python binding, 2026-04-14, commits `d3a14a73` + `18bb703b`). Pre-fix, the PyO3 wrapper formatted the full 4KB Rust-side body into the Python exception message, producing 400-line tracebacks that drowned the real error signal. The fix introduced `PY_SERVICE_CLIENT_ERROR_BODY_BYTES = 512` plus `truncate_py_error_body` called at the PyErr conversion site, while the Rust crate kept its 4KB `MAX_ERROR_BODY_BYTES` for forensic logging. Generalises to any PyO3 wrapper of a Rust error type with body fields.

--- a/.claude/skills/06-python-bindings/typed-exception-hierarchy.md
+++ b/.claude/skills/06-python-bindings/typed-exception-hierarchy.md
@@ -1,0 +1,285 @@
+---
+name: typed-exception-hierarchy
+description: "Split a Rust error enum into a typed PyO3 exception hierarchy so Python callers can `except` discrete failure modes without parsing exception messages. Use when wrapping any Rust error enum that has more than 2 distinct failure modes for a Python binding."
+priority: HIGH
+tags: [pyo3, python-binding, error-handling, exceptions, rust-binding]
+paths:
+  - "bindings/kailash-python/**"
+  - "bindings/kailash-ruby/**"
+---
+
+# Typed Exception Hierarchy For PyO3 Wrappers
+
+When a Rust function returns `Result<T, MyError>` and `MyError` is an enum with multiple variants, the naive PyO3 wrapper raises a single Python exception type for every variant — forcing Python callers to either catch everything with one `except` and lose information, or `str(e)`-match exception messages and bind their code to the *exact wording* of error messages. Both are wrong.
+
+The correct pattern is a **typed exception hierarchy**: one base class per Rust error enum, plus one PyO3 subclass per error variant. The conversion function dispatches each Rust variant to its corresponding Python subclass. Python callers then `except SubclassName` for the specific failure mode they care about, and `except BaseClass` for "anything from this subsystem".
+
+This is the canonical pattern for wrapping any Rust error enum with ≥3 variants in a Python binding. Below 3 variants, a flat exception type is acceptable; at or above 3, the typed hierarchy is mandatory.
+
+## When To Use
+
+| Variants in the Rust enum | Use this pattern? |
+| --- | --- |
+| 1 (single failure mode) | No — a single exception type is fine |
+| 2 (e.g., `Timeout` / `Other`) | Optional — only if the two are semantically distinct enough that callers want to handle them differently |
+| 3+ (typed errors with distinct call-site reactions) | **Yes — mandatory** |
+
+## The Pattern
+
+### Step 1: Define The Base Class And One Subclass Per Variant
+
+In the PyO3 module, use the `pyo3::create_exception!` macro to declare a base class and one subclass per Rust enum variant. The base inherits from `PyException`; the subclasses inherit from the base.
+
+```rust
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+
+// Base — catches everything from this subsystem
+create_exception!(
+    kailash,                          // module name (must match #[pymodule])
+    ServiceClientError,               // class name visible in Python
+    PyException,                      // base
+    "Base class for all ServiceClient failures."
+);
+
+// One subclass per Rust enum variant
+create_exception!(kailash, ServiceClientHttpError,           ServiceClientError,
+    "Network or transport failure (SSRF blocked, timeout, connection error, invalid URL).");
+create_exception!(kailash, ServiceClientHttpStatusError,     ServiceClientError,
+    "HTTP response with non-2xx status code.");
+create_exception!(kailash, ServiceClientSerializeError,      ServiceClientError,
+    "Failed to JSON-encode the request body.");
+create_exception!(kailash, ServiceClientDeserializeError,    ServiceClientError,
+    "Failed to JSON-decode the response body.");
+create_exception!(kailash, ServiceClientInvalidPathError,    ServiceClientError,
+    "Base URL and path could not be joined.");
+create_exception!(kailash, ServiceClientInvalidHeaderError,  ServiceClientError,
+    "Header name or value rejected by the validator.");
+```
+
+### Step 2: Register All Classes In The Module
+
+Every subclass MUST be registered in the `#[pymodule]` function alongside the base. Missing a registration makes the class invisible to Python and breaks `isinstance()` checks.
+
+```rust
+#[pymodule]
+fn kailash(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("ServiceClientError",                py.get_type::<ServiceClientError>())?;
+    m.add("ServiceClientHttpError",            py.get_type::<ServiceClientHttpError>())?;
+    m.add("ServiceClientHttpStatusError",      py.get_type::<ServiceClientHttpStatusError>())?;
+    m.add("ServiceClientSerializeError",       py.get_type::<ServiceClientSerializeError>())?;
+    m.add("ServiceClientDeserializeError",     py.get_type::<ServiceClientDeserializeError>())?;
+    m.add("ServiceClientInvalidPathError",     py.get_type::<ServiceClientInvalidPathError>())?;
+    m.add("ServiceClientInvalidHeaderError",   py.get_type::<ServiceClientInvalidHeaderError>())?;
+    Ok(())
+}
+```
+
+### Step 3: Dispatched Conversion Function
+
+Write ONE conversion function from the Rust error enum to a `PyErr`. It MUST exhaustively match every variant (no wildcard `_ =>`) so adding a new variant to the Rust enum is a compile error until the conversion function is updated.
+
+```rust
+fn service_client_err_to_pyerr(err: kailash_nexus::service_client::ServiceClientError) -> PyErr {
+    use kailash_nexus::service_client::ServiceClientError as E;
+    match &err {
+        E::Http(inner) =>
+            ServiceClientHttpError::new_err(format!("http: {inner}")),
+
+        E::SerializeRequest(s) =>
+            ServiceClientSerializeError::new_err(format!("serialize_request: {s}")),
+
+        E::DeserializeResponse { status, body, error } => {
+            let body_short = truncate_py_error_body(body);   // see layered-truncation skill
+            ServiceClientDeserializeError::new_err(format!(
+                "deserialize_response status={status} error={error} body={body_short}"
+            ))
+        },
+
+        E::HttpStatus { status, body } => {
+            let body_short = truncate_py_error_body(body);
+            ServiceClientHttpStatusError::new_err(format!(
+                "http_status status={status} body={body_short}"
+            ))
+        },
+
+        E::InvalidPath(s) =>
+            ServiceClientInvalidPathError::new_err(format!("invalid_path: {s}")),
+
+        E::InvalidHeader(s) =>
+            ServiceClientInvalidHeaderError::new_err(format!("invalid_header: {s}")),
+    }
+}
+```
+
+### Step 4: Use The Conversion At Every Boundary
+
+Every PyO3 method that calls into the Rust crate MUST route the `Result` through `service_client_err_to_pyerr` (or its equivalent), never wrap with a generic `PyValueError::new_err(format!("{e}"))`.
+
+```rust
+#[pymethods]
+impl PyServiceClient {
+    fn get(&self, path: &str) -> PyResult<PyObject> {
+        let result = self.tokio_rt.block_on(async {
+            self.inner.get_raw(path).await
+        });
+        match result {
+            Ok(resp) => Python::with_gil(|py| http_response_to_dict(py, &resp)),
+            Err(e) => Err(service_client_err_to_pyerr(e)),    // typed dispatch
+        }
+    }
+}
+```
+
+### Step 5: Python Caller-Side Discrimination
+
+Python callers can now `except` specific subclasses, or fall back to the base class for anything the subsystem raises:
+
+```python
+import kailash
+
+client = kailash.ServiceClient("https://api.example.com", allowed_hosts=["api.example.com"])
+
+try:
+    user = client.post("/users", {"name": "Alice"})
+except kailash.ServiceClientHttpStatusError as e:
+    # 4xx/5xx response
+    log.warn("backend rejected request", error=str(e))
+    return None
+except kailash.ServiceClientDeserializeError as e:
+    # response body was not valid JSON
+    log.error("backend returned malformed json", error=str(e))
+    raise
+except kailash.ServiceClientInvalidHeaderError as e:
+    # caller bug — bad header passed at construction time
+    raise
+except kailash.ServiceClientError as e:
+    # any other failure from the ServiceClient subsystem
+    log.error("service client failure", error=str(e))
+    raise
+```
+
+## DO / DO NOT
+
+```python
+# DO — catch the specific subclass for the failure mode you can recover from
+try:
+    user = client.get("/users/42")
+except kailash.ServiceClientHttpStatusError:
+    return None  # treat 404 as "no user"
+except kailash.ServiceClientError:
+    raise        # everything else is fatal
+
+# DO NOT — string-match the exception message
+try:
+    user = client.get("/users/42")
+except kailash.ServiceClientError as e:
+    if "404" in str(e):           # BLOCKED — fragile, breaks on message rewording
+        return None
+    if "deserialize" in str(e):    # BLOCKED — couples Python code to Rust message format
+        raise
+```
+
+## MUST Rules
+
+### 1. Exhaustive Match In The Conversion Function
+
+The Rust → Python error conversion MUST exhaustively match every variant of the Rust enum. Wildcard `_ => generic_error(...)` is BLOCKED.
+
+```rust
+// DO — exhaustive
+match &err {
+    E::Http(_) => ...,
+    E::HttpStatus { .. } => ...,
+    E::SerializeRequest(_) => ...,
+    E::DeserializeResponse { .. } => ...,
+    E::InvalidPath(_) => ...,
+    E::InvalidHeader(_) => ...,
+}
+
+// DO NOT — wildcard catch-all
+match &err {
+    E::Http(_) => ServiceClientHttpError::new_err(...),
+    _ => ServiceClientError::new_err(format!("{err}")),   // BLOCKED
+}
+```
+
+**Why:** A wildcard hides the moment a new variant is added to the Rust enum. The new variant gets dispatched to the generic base class, Python callers cannot discriminate it, and the typed-discrimination guarantee silently degrades. Exhaustive matching turns the new variant into a compile error that forces the binding author to add a new subclass.
+
+### 2. Subclass Per Variant, Not Subclass Per Severity
+
+The hierarchy MUST follow the *Rust enum's variant structure*, not a hand-designed severity taxonomy. One subclass per variant, named after the variant.
+
+```rust
+// DO — variant-shaped hierarchy
+ServiceClientHttpError          // for E::Http
+ServiceClientHttpStatusError    // for E::HttpStatus
+ServiceClientSerializeError     // for E::SerializeRequest
+ServiceClientDeserializeError   // for E::DeserializeResponse
+
+// DO NOT — severity-shaped hierarchy
+ServiceClientFatalError         // for "everything bad"
+ServiceClientWarningError       // for "everything we can retry"
+```
+
+**Why:** Severity classifications are caller-specific (one caller's fatal is another's warning). Variant-shaped hierarchies preserve the structural information from the Rust enum and let each caller make its own severity decision.
+
+### 3. Conversion Function Lives Next To The Class Definitions
+
+The `*_err_to_pyerr()` function MUST live in the same file as the `create_exception!` declarations. Splitting them across files makes it possible to add a Rust enum variant + a new Python class without updating the dispatcher.
+
+**Why:** Co-location is the structural defense against drift. Cross-file split + grep is not.
+
+## Security Caution: Exception Messages May Contain Secrets
+
+Exception messages produced by this hierarchy may include URL fragments (from `InvalidPath` / `InvalidUrl` variants) and upstream response body content (from `HttpStatus` / `Deserialize` variants, even after layered truncation). Both can carry secrets that the upstream service or the caller embedded in the inputs:
+
+- A malformed URL like `https://user:tokenABC@host/` would surface `tokenABC` in `ServiceClientInvalidPathError.__str__`.
+- An upstream service returning `{"error": "session XYZ123 expired"}` would surface `XYZ123` in `ServiceClientHttpStatusError.__str__`.
+
+```python
+# DO — redact before logging at INFO or above
+try:
+    user = client.get("/users/42")
+except kailash.ServiceClientError as e:
+    logger.info("api call failed", error=mask_credentials(str(e)))
+    raise
+
+# DO NOT — log raw exception messages at INFO/WARN
+try:
+    user = client.get("/users/42")
+except kailash.ServiceClientError as e:
+    logger.info("api call failed", error=str(e))   # may leak tokens, response-body secrets
+    raise
+```
+
+**Why:** Log aggregators (Datadog, Splunk, CloudWatch) are accessible to a broader audience than the production database. A `ServiceClientHttpStatusError` body containing a session token, even after 512-byte truncation, will reach every log reader. Treat exception messages as untrusted upstream content. See `rules/security.md` § "No secrets in logs".
+
+**BLOCKED rationalizations:**
+
+- "The truncation already keeps the body small, secrets won't leak"
+- "We trust the upstream service not to put secrets in error bodies"
+- "logger.info is for debugging, it's fine"
+- "We can scrub the logs after the fact"
+
+## MUST NOT
+
+- Wrap a multi-variant Rust enum with `PyValueError::new_err(format!("{e}"))`
+
+**Why:** Loses every distinction the Rust enum encoded; forces callers to string-match.
+
+- Re-define the same exception class in multiple PyO3 modules
+
+**Why:** `isinstance()` checks fail across module boundaries because the two classes have different identities.
+
+- Skip registering a subclass in the `#[pymodule]` block
+
+**Why:** Unregistered classes are invisible to Python `isinstance()` and `from kailash import X` fails with `ImportError`.
+
+## Related Skills
+
+- `skills/06-python-bindings/layered-truncation.md` — pairs with this skill: when an error variant carries a body field, route it through `truncate_py_error_body` so the Python exception message stays under ~512 bytes
+- `skills/18-security-patterns/header-validation-at-construction.md` — pairs with this skill: the `InvalidHeader` variant in the example above is what makes constructor-time header validation surfaceable to Python callers
+- `skills/06-python-bindings/SKILL.md` — overview of Python binding patterns
+
+Origin: BP-041 (kailash-rs ServiceClient Python binding hardening, 2026-04-14, commits `d3a14a73` + `18bb703b`). The pre-fix `PyServiceClient` raised a single `ServiceClientError` for 6 distinct failure modes, forcing Python callers to parse exception messages. The fix introduced a base class plus 6 typed subclasses with dispatched conversion. The pattern is reusable for every PyO3 wrapper of a Rust error enum with ≥3 variants.

--- a/.claude/skills/12-testing-strategies/impossibility-surface.md
+++ b/.claude/skills/12-testing-strategies/impossibility-surface.md
@@ -1,0 +1,152 @@
+---
+name: impossibility-surface
+description: "Justify happy-path test gaps that a lower-layer security control makes physically unreachable. Use when a test you 'should' write cannot be executed and you need to document why so auditors don't file the missing test as a bug."
+priority: HIGH
+tags: [testing, security, ssrf, allowlist, binding-layer, audit]
+paths:
+  - "tests/**"
+  - "**/*test*"
+  - "**/*spec*"
+---
+
+# Impossibility Surface
+
+When a happy-path test for a layer cannot run because a documented security control or OS-level constraint at a *lower* layer makes it physically impossible, that test gap is an **impossibility surface**. The pattern says: write the gap down with the *reason* and a *link to where the coverage actually lives*, so future auditors don't file the missing test as a defect and the next contributor doesn't try to "fix" it by weakening the security control.
+
+This is **not** a blanket excuse to skip tests. It is a narrow pattern for one specific situation: the test physically cannot run.
+
+## Scope — What This Skill IS And IS NOT
+
+**This pattern IS** a justification framework for happy-path coverage that genuinely cannot run at the layer being tested. The canonical example: a Python binding test that tries to wire a wiremock server bound to `127.0.0.1` on the loopback interface, but the underlying Rust HTTP client's SSRF guard blocks every loopback IP before the request leaves the binding. The happy path is documented and exercised at the lower layer (Rust wiremock suite); the higher layer (Python binding) cannot reach it without disabling the security control that is the entire point of the binding.
+
+**This pattern is NOT** any of the following:
+
+- A reason to skip **error-path tests**. Error paths are the entire reason the binding layer exists. They MUST be exercised at every layer.
+- A reason to skip **eager-validation tests** (constructor-time rejection of bad input). Eager validation is fast, has no SSRF dependency, and MUST be tested at every layer.
+- A reason to skip **rejection-behavior tests** (the test that proves the security control fires). Those are the most important tests; without them the control could be silently broken.
+- A reason to skip a test because the test setup is *inconvenient*, *slow*, or *requires more infrastructure than the author wants to write*. Those gaps are technical debt, not impossibility surfaces.
+- A reason to skip a test because *the team hasn't gotten to it yet*. That is a TODO, not an impossibility.
+
+**The test:** a gap is an impossibility surface only if the answer to *"what would it take to write this test?"* is *"weaken or bypass a documented security control, or run the test in an environment that doesn't exist."* If the answer is *"more time"* or *"a fixture I haven't built"*, it is not an impossibility surface.
+
+## MUST Rules
+
+### 1. Document The Impossibility Surface At The Top Of The Test File
+
+When a test file deliberately omits a category of test (e.g., happy-path roundtrips) because of an impossibility surface, the file MUST open with a docstring or comment block that:
+
+1. States WHICH category of test is missing and at this layer
+2. States WHY the lower-layer control makes it impossible (named control, file/line reference if available)
+3. POINTS to the file/path where the coverage actually lives at the lower layer
+4. CONFIRMS that error paths, rejection behavior, and eager validation ARE covered in this file
+
+```python
+# DO — opens with a clear impossibility-surface declaration
+"""Tests for the Python binding of the ServiceClient.
+
+These tests deliberately do NOT spin up a real HTTP server. The inner
+HttpClient blocks every loopback and private IP (127.0.0.1, 10.x,
+192.168.x, 169.254.x) before the allowlist check runs, so a
+"roundtrip against localhost" is not reachable from Python — wiremock
+binds to loopback and the SSRF guard rejects it before the request
+leaves the binding.
+
+Happy-path wiremock coverage lives in:
+    crates/kailash-nexus/src/service_client.rs
+    (lines 947-1300+, ~50 wiremock-backed test functions)
+
+What THIS file covers:
+- Module exports + exception hierarchy (lines 43-94)
+- Constructor validation + header rejection (lines 101-165)
+- SSRF blocking on every method, every private-IP shape (lines 172-239)
+- Allowlist enforcement (lines 246-258)
+- Exception class distinctness + type correctness (lines 265-306)
+"""
+
+# DO NOT — silently omit happy-path tests with no explanation
+"""Tests for the ServiceClient Python binding."""
+
+def test_constructor_rejects_invalid_url(): ...
+def test_get_blocks_loopback(): ...
+# (where are the happy-path tests? auditor files a HIGH finding)
+```
+
+**Why:** Without the docstring, the next auditor running coverage analysis sees "no happy-path tests for `client.get()` at the Python layer" and files it as a HIGH gap. They then waste hours either re-writing the test (which fails for the same reason) or trying to disable the SSRF guard (which is the security control). The docstring is the cheapest possible defense against repeat-discovery.
+
+### 2. Link Both Directions
+
+The lower-layer test file (where the happy paths live) MUST also have a comment near the wiremock fixture pointing back to the higher-layer test file, so anyone editing the SSRF guard sees both places that depend on it.
+
+```rust
+// DO — bidirectional cross-reference in the Rust test file
+// NOTE: These wiremock tests are the ONLY happy-path coverage for
+// ServiceClient. The Python binding tests at
+// `bindings/kailash-python/tests/test_service_client.py` cannot
+// reach happy paths because HttpClient::validate_url() blocks
+// loopback before the allowlist is checked. If you change the
+// SSRF guard, both files need to be reviewed together.
+#[tokio::test]
+async fn get_typed_success() { ... }
+
+# DO NOT — wiremock fixture with no reference back to the binding-layer constraint
+#[tokio::test]
+async fn get_typed_success() { /* wiremock setup */ }
+# (the next person to "harden" the SSRF guard breaks the binding tests
+#  and doesn't know they should look at the Rust suite for the gap)
+```
+
+**Why:** Single-direction documentation rots the moment the lower-layer file is refactored. Bidirectional cross-references are the structural defense against drift.
+
+### 3. The Impossibility Must Be Verified, Not Assumed
+
+Before declaring a test "impossible at this layer" the author MUST attempt to write it once and observe the actual failure. Document the failure mode (which security control, which line, which exception). "I think the SSRF guard would block this so I won't try" is BLOCKED.
+
+```python
+# DO — verified impossibility, observed failure mode
+# Attempted 2026-04-14: tried to wire `wiremock` against 127.0.0.1:randomport
+# and call client.get("/health"). Result: ServiceClientHttpError raised at
+# request time with message "URL points to private/loopback network",
+# from HttpClient::validate_url() at http_client.rs:300 (private/loopback
+# block). Confirmed the SSRF guard (Layer 3) fires BEFORE the allowlist
+# (Layer 4 at line 306-307), so even `allowed_hosts=["127.0.0.1"]` does
+# not bypass it. Test confirms this: `allowlist_still_blocks_private_ips`.
+
+# DO NOT — assumed impossibility, no verification
+# (no comment, just "doesn't make sense to test this here")
+```
+
+**Why:** Assumed impossibilities are how real test gaps get hidden. A 5-minute experiment confirms whether the gap is genuine and produces the exact reference the docstring needs.
+
+## MUST NOT
+
+- Cite "impossibility surface" to skip an **error-path test**
+
+**Why:** Error paths are testable at every layer (the error itself is the assertion). Skipping an error-path test by citing an impossibility surface is exactly the rationalization this skill exists to prevent.
+
+- Cite "impossibility surface" to skip an **eager-validation test** (constructor-time rejection)
+
+**Why:** Eager validation runs in `__init__` / `new()` — it never reaches the lower-layer security control, so the security control cannot make it impossible.
+
+- Cite "impossibility surface" to skip a **rejection-behavior test** that proves the security control fires
+
+**Why:** Rejection tests ARE the test of the security control. Skipping them means the control could silently break and nothing would notice.
+
+- Use "impossibility surface" as a synonym for "I haven't written this yet"
+
+**Why:** That is a TODO. Mark it as a TODO and either fix it or convert it to a real impossibility surface with the verified failure mode.
+
+**BLOCKED rationalizations:**
+
+- "The lower layer covers it, so we don't need it here"
+- "It would be redundant to test it at both layers"
+- "The test would just exercise the security control, not the new code"
+- "Setting up wiremock at this layer is too much work"
+- "The team hasn't gotten to it yet"
+
+## Cross-References
+
+- `rules/testing.md` — Tier coverage requirements; impossibility surfaces are exceptions to per-tier coverage rules and MUST be documented.
+- `skills/spec-compliance/SKILL.md` — Spec-compliance verification protocol; auditors checking new modules for tests should consult impossibility-surface declarations before filing gaps.
+- Layered system coverage (when one layer wraps another) is a recurring pattern across Kailash framework boundaries (Python bindings → Rust core, Nexus → DataFlow, Trust plane → application code). The same docstring pattern applies wherever a higher layer cannot reach a lower-layer-protected path.
+
+Origin: BP-047 (kailash-rs ServiceClient Python binding, 2026-04-14, commit d3a14a73). The Python test file at `bindings/kailash-python/tests/test_service_client.py` cannot exercise happy-path roundtrips because `HttpClient::validate_url()` in `crates/kailash-nexus/src/http_client.rs:264` blocks loopback before the allowlist runs. The 38 Python tests cover error paths, eager validation, and rejection behavior; happy-path coverage stays in the Rust wiremock suite. Without the docstring at the top of the Python test file, every code review re-discovered the gap.

--- a/.claude/skills/18-security-patterns/header-validation-at-construction.md
+++ b/.claude/skills/18-security-patterns/header-validation-at-construction.md
@@ -1,0 +1,246 @@
+---
+name: header-validation-at-construction
+description: "Validate HTTP header names and values at construction time, not at first request. Builder methods accepting headers MUST return Result so a CRLF-injected token fails in the constructor, not on the first .get() call. Use for any HTTP client that accepts caller-supplied header content."
+priority: HIGH
+tags: [http-client, security, header-injection, crlf, ssrf-adjacent, eager-validation]
+paths:
+  - "bindings/kailash-python/**"
+  - "crates/kailash-nexus/**"
+  - "**/http_client*"
+  - "**/service_client*"
+---
+
+# Header Validation At Construction
+
+When an HTTP client builder accepts caller-supplied header names and values — including the bearer token convenience method — the validation of those headers MUST run at *construction time*, not at first request time. Late validation is a security bug class: a CRLF-injected value that gets stored in a builder and only fails on the first `.get()` call has already been written into a `HeaderMap`, exists in memory, and may have leaked into logs or other code paths before it surfaces.
+
+The pattern: every header-accepting builder method returns `Result<Self, ServiceClientError>` (in Rust) or raises a typed exception in `__init__` (in Python bindings). The validation runs through the same `try_with_header` helper that the typed `with_bearer_token` convenience routes through, so there is exactly one validation site for every header that ever enters the builder.
+
+## Scope — Why "At Construction" Matters
+
+**Header injection (CRLF) attack:** an attacker who controls *part of* a header value can inject `\r\n` followed by additional header lines, request smuggling payloads, or fake response splitting. The classic case is an authenticated endpoint that does `bearer_token = format!("Bearer {}", user_supplied_token)` and accepts a token containing `\r\nX-Admin: 1`. If the validator runs at first request, the bad value sits in the builder until then; if the validator runs at construction, the builder fails immediately and the attacker's payload never reaches the request layer.
+
+**Why "convenience methods route through the validator":** a common bug is exposing a strict `try_with_header` AND a "convenient" `with_bearer_token(token: &str) -> Self` that bypasses the validator. The convenience method becomes the actual call site for 99% of bearer-token uses, and the strict validator never runs. The fix is the v3.16.1 hotfix below: every convenience method is itself fallible and routes through the strict validator.
+
+This pattern is scoped to **header-specific validation** in HTTP/PyO3 contexts. Do NOT generalize to "all constructor-time validation" until a second data point (URL validation, credential validation, etc.) confirms the same builder-returning-Result shape works cross-concern.
+
+## The Pattern
+
+### Step 1: Builder Returns `Result<Self, _>` On Header-Accepting Methods
+
+```rust
+// crates/kailash-nexus/src/service_client.rs
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceClientError {
+    // ...
+    #[error("invalid header: {0}")]
+    InvalidHeader(String),
+    // ...
+}
+
+impl ServiceClient {
+    /// Add a custom header, validated at construction time.
+    pub fn try_with_header(
+        self,
+        key: impl AsRef<str>,
+        value: impl AsRef<str>,
+    ) -> Result<Self, ServiceClientError> {
+        let k = key.as_ref();
+        let v = value.as_ref();
+
+        // Validate name
+        let header_name = reqwest::header::HeaderName::try_from(k)
+            .map_err(|e| ServiceClientError::InvalidHeader(
+                format!("invalid header name: {e}")
+            ))?;
+
+        // Validate value (rejects \r, \n, NUL, non-ASCII)
+        let header_value = reqwest::header::HeaderValue::try_from(v)
+            .map_err(|e| ServiceClientError::InvalidHeader(
+                format!("invalid header value: {e}")
+            ))?;
+
+        let mut s = self;
+        s.headers.insert(header_name, header_value);
+        Ok(s)
+    }
+
+    /// Convenience for Authorization: Bearer <token>.
+    /// Routes through try_with_header so CRLF in the token fails here, not at request time.
+    pub fn with_bearer_token(self, token: &str) -> Result<Self, ServiceClientError> {
+        self.try_with_header("Authorization", format!("Bearer {token}"))
+    }
+}
+```
+
+Two things matter:
+
+1. **The validator is `reqwest::header::HeaderValue::try_from`** (or `http::HeaderValue::try_from`) on the `&str` path. It rejects `\r`, `\n`, `\0`, and other non-printable control characters — exactly the bytes used in CRLF injection. (`HeaderValue::from_bytes` accepts RFC 7230 `obs-text` 0x80–0xFF and is intentionally NOT used here; the `&str` path is stricter.) Do NOT roll your own validator.
+2. **`with_bearer_token` is itself fallible and delegates to `try_with_header`.** The convenience method does NOT bypass validation. This is the v3.16.1 hotfix that turned a fake-security claim into a real one.
+
+### Step 2: Builder Chain Uses `?` (Or Equivalent) At Every Step
+
+```rust
+let client = ServiceClient::new("https://api.example.com")
+    .try_with_header("X-Request-Id", request_id)?            // fails here if bad
+    .with_bearer_token(&token)?                              // also fails here, not at first request
+    .with_allowed_hosts(vec!["api.example.com".into()]);     // non-fallible; no `?`
+
+let user = client.get::<User>("/users/42").await?;
+```
+
+In Python (where `__init__` cannot return `Result`), the same validation runs at construction and raises a typed exception:
+
+```python
+import kailash
+
+# Header validation runs in __init__
+try:
+    client = kailash.ServiceClient(
+        base_url="https://api.example.com",
+        allowed_hosts=["api.example.com"],
+        bearer_token=user_token,                              # validated here
+        headers={
+            "X-Request-Id": request_id,                       # validated here
+            "X-Tenant": tenant_id,                            # validated here
+        },
+    )
+except kailash.ServiceClientInvalidHeaderError as e:
+    # Caller passed something unsanitized — the bad header NEVER reaches the request layer
+    log.error("rejected client construction", error=str(e))
+    raise
+
+# By the time we reach .get(), every header has already passed the validator.
+user = client.get("/users/42")
+```
+
+### Step 3: CRLF Injection Is Now Caught At Construction
+
+```python
+# This raises ServiceClientInvalidHeaderError immediately, BEFORE any request is sent.
+# The bad value never enters the HeaderMap.
+try:
+    bad = kailash.ServiceClient(
+        base_url="https://api.example.com",
+        allowed_hosts=["api.example.com"],
+        bearer_token="good-token\r\nX-Admin: 1",              # CRLF injection attempt
+    )
+except kailash.ServiceClientInvalidHeaderError as e:
+    print(f"Caught at construction: {e}")
+    # Caught at construction: invalid_header: invalid header value: failed to parse header value
+```
+
+Same for header values containing null bytes, header names with whitespace, header values with non-ASCII bytes, etc. — every case is caught by `HeaderValue::try_from` / `HeaderName::try_from` before the builder returns.
+
+## DO / DO NOT
+
+```rust
+// DO — fallible builder, single validator, convenience methods delegate
+pub fn try_with_header(self, k: impl AsRef<str>, v: impl AsRef<str>)
+    -> Result<Self, ServiceClientError> { /* validates both, returns Result */ }
+
+pub fn with_bearer_token(self, token: &str) -> Result<Self, ServiceClientError> {
+    self.try_with_header("Authorization", format!("Bearer {token}"))
+}
+
+// DO NOT — infallible builder, validation deferred to request time
+pub fn with_header(self, k: &str, v: &str) -> Self {
+    let mut s = self;
+    s.headers.insert(
+        HeaderName::from_static(k),                           // panics on bad input
+        HeaderValue::from_str(v).unwrap(),                    // BLOCKED — unwrap on user input
+    );
+    s
+}
+
+// DO NOT — convenience method bypasses the validator
+pub fn with_bearer_token(self, token: &str) -> Self {
+    let value = format!("Bearer {token}");                    // CRLF survives here
+    let mut s = self;
+    s.headers.insert(AUTHORIZATION, HeaderValue::from_str(&value).unwrap_or_default());
+    s   // BLOCKED — bad token silently became empty header, or panicked
+}
+```
+
+## MUST Rules
+
+### 1. Every Header-Accepting Builder Method Returns `Result`
+
+Any builder method, constructor parameter, or setter that takes a header name or header value MUST return `Result<Self, _>` (Rust) or raise at `__init__` time (Python). Infallible setters that take caller-supplied header content are BLOCKED.
+
+```rust
+// DO
+pub fn try_with_header(self, k: impl AsRef<str>, v: impl AsRef<str>) -> Result<Self, _>
+
+// DO NOT
+pub fn with_header(self, k: &str, v: &str) -> Self
+```
+
+**Why:** Late validation moves the failure from a synchronous, deterministic, attacker-visible point (construction) to an asynchronous, request-time point where the bad value has already been stored, possibly logged, possibly leaked through other code paths.
+
+### 2. Convenience Methods Route Through The Strict Validator
+
+Every "convenient" header-setting method (`with_bearer_token`, `with_basic_auth`, `with_user_agent`, `with_correlation_id`) MUST call `try_with_header` internally. Direct `HeaderMap::insert(...)` from a convenience method is BLOCKED.
+
+```rust
+// DO — convenience methods are fallible and delegate
+pub fn with_bearer_token(self, token: &str) -> Result<Self, ServiceClientError> {
+    self.try_with_header("Authorization", format!("Bearer {token}"))
+}
+
+// DO NOT — convenience method side-channels the validator
+pub fn with_bearer_token(self, token: &str) -> Self {
+    self.headers.insert(AUTHORIZATION, HeaderValue::from_str(&format!("Bearer {token}")).unwrap());
+    self
+}
+```
+
+**BLOCKED rationalizations:**
+
+- "Bearer tokens are usually JWTs without CRLF, so validation is overkill"
+- "We trust the caller to sanitize"
+- "The convenience method exists *because* it's quick — adding `?` defeats the purpose"
+- "We'll add validation in v2"
+
+**Why:** The convenience method becomes the dominant call site (≥95% of bearer-token uses); the strict path becomes the exception. Routing the convenience method through the strict path is the only way to ensure validation actually runs in production.
+
+### 3. Use The Crate's Own Header Validators, Never Hand-Rolled Regexes
+
+The `reqwest::header::HeaderName::try_from` and `reqwest::header::HeaderValue::try_from` validators (or `http::*` equivalents) MUST be the validators used. Hand-rolled regex or character-class checks are BLOCKED.
+
+```rust
+// DO — use the library validators
+let name = reqwest::header::HeaderName::try_from(k)?;
+let value = reqwest::header::HeaderValue::try_from(v)?;
+
+// DO NOT — hand-rolled validation
+if v.contains('\r') || v.contains('\n') {                     // BLOCKED — incomplete
+    return Err(...);
+}
+let value = HeaderValue::from_str(v).unwrap();
+```
+
+**Why:** The library validators implement the full RFC 7230 token / VCHAR / OWS rules and are kept in sync with HTTP spec updates. Hand-rolled checks miss edge cases (NUL bytes, DEL, non-ASCII Latin-1, obs-text) and silently re-introduce the vulnerability the validation was supposed to prevent.
+
+## MUST NOT
+
+- Store unvalidated header bytes in any builder field, even temporarily
+
+**Why:** Once the bytes are in memory, any code path that touches the builder can leak them into logs, tracing spans, or downstream HTTP requests before the late validator runs.
+
+- Use `HeaderValue::from_str(...).unwrap()` or `HeaderValue::from_static(...)` on user-controlled input
+
+**Why:** `unwrap()` panics across the FFI boundary; `from_static` requires a `'static` lifetime which user input never has. Both are silent vectors back to the unsafe path.
+
+- Defer header validation to "the next request" or "when the connection is established"
+
+**Why:** That moves the failure from synchronous construction (caller can handle it) to asynchronous request time (caller's `try/except` is around the wrong code), making the error harder to attribute and easier to swallow.
+
+## Related Skills
+
+- `skills/06-python-bindings/typed-exception-hierarchy.md` — the `ServiceClientInvalidHeaderError` subclass surfaced by this validator is part of the typed exception hierarchy
+- `skills/18-security-patterns/network-security-rs.md` — broader Rust network-hardening patterns (DNS rebinding, allowlists, TLS verification)
+- `skills/18-security-patterns/fail-closed-defaults-rs.md` — the construction-time validation pattern is a specific case of "fail closed at the earliest possible moment"
+
+Origin: BP-042 (kailash-rs ServiceClient header validation, 2026-04-14, commits `d3a14a73` + `18bb703b` + v3.16.1 hotfix). The v3.16.0 cut initially documented `with_bearer_token` as "routed through `try_with_header`", but the Rust implementation still called the infallible `with_header` — a fake-security claim. The v3.16.1 hotfix made `with_bearer_token` return `Result<Self, ServiceClientError>` and delegate to `try_with_header`. The skill codifies the actual shipped pattern: every header-accepting method is fallible, and every convenience method routes through the strict validator. Tier set to variant-rs because the Rust signature (`Result<Self, _>` builder chain with double-`?`) is idiomatic Rust; the Python and Ruby bindings inherit the validation by calling through `__init__`.


### PR DESCRIPTION
## Summary

- 4 NEW skills authored from kailash-rs BP-041..047 source: impossibility-surface (global), typed-exception-hierarchy + layered-truncation + header-validation-at-construction (variant-rs)
- 1 NEW agent placement: ffi-specialist (first-time at USE template, PyO3/napi-rs/wasm/CGo/JNA)
- testing.md: Delegating Primitives Need Direct Coverage section with TEST_DIR-relative grep enforcement
- nexus-specialist: ServiceClient + HttpClient Python-binding usage section + 6 invariants + cross-references

## Test plan

- [x] All 4 new skills verified against actual Rust source (service_client.rs, http_client.rs, nexus.rs PyO3 wrapper)
- [x] reviewer (APPROVED WITH MINOR FIXES) + security-reviewer (APPROVED WITH MINOR FIXES) both ran in parallel; all medium fixes applied
- [x] Hooks 12/12 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)