### PR TITLE
feat(coc): sync loom 2.8.19 — 7 cross-SDK rule extensions (2.9.8)

### DIFF
--- a/.claude/.coc-sync-marker
+++ b/.claude/.coc-sync-marker
@@ -1,19 +1,32 @@
-last_synced: "2026-04-19T11:15:00Z"
-loom_version: "2.8.18"
-template_version: "2.9.7"
-sync_direction: "Gate 2 single-file body-shape correction — loom 2.8.17 → 2.8.18. Reconciles nexus-http-status-convention skill body shape ({error, status} → {error, code}) to match SDK contract verified by red-team grep against 8 production refs in crates/kailash-nexus/src/."
-scope: "1 file changed (MODIFIED). No SDK pin change. No manifest change. No variant/rs overlays affected."
+last_synced: "2026-04-19T14:30:00Z"
+loom_version: "2.8.19"
+template_version: "2.9.8"
+sync_direction: "Gate 2 single-cycle cross-SDK catch-up — loom 2.8.19 → rs USE template 2.9.8. Delivers 7 global rule extensions from kailash-py round-10 post-release audit codify (cross-SDK, language-agnostic patterns). No rs SDK release in this cycle; Cargo pins unchanged."
+scope: "7 rule files updated (4 overwrites + 3 merges to preserve rs-variant content). No SDK pin change. No manifest change. Gate 1 classification reused from py Gate 2 run."
 files:
-  - .claude/skills/03-nexus/nexus-http-status-convention.md                  # MODIFIED (rewritten 186 → 179 lines; body shape {error, status} → {error, code}; catalog expanded with code column; NexusHandlerError examples; handler_extract API)
-  - .claude/VERSION                                                          # UPDATED (2.9.6 → 2.9.7, upstream 2.8.17 → 2.8.18)
+  - .claude/rules/tenant-isolation.md                                        # OVERWRITE (no rs variant; +Rule 3a Keyspace Version Bumps invalidation-path sweep, 112 → 140 lines)
+  - .claude/rules/orphan-detection.md                                        # OVERWRITE (no rs variant; +Rule 6 Module-Scope Public Imports in __all__, 151 → 192 lines; Python __all__ pattern lands on Python/Ruby binding-consumer rs template per manifest)
+  - .claude/rules/cross-sdk-inspection.md                                    # OVERWRITE (no rs variant; +§3a Structural API-Divergence Disposition + §5 Cross-SDK Symbol Citations Grep-Verified)
+  - .claude/rules/dependencies.md                                            # OVERWRITE (no rs variant; +Phantom Transitive Deps multi-ecosystem section covering uv/cargo/npm)
+  - .claude/rules/agents.md                                                  # MERGE (rs variant — +Quality Gates post-release audit row + Verify Agent Deliverables section + worktree-isolation.md cross-ref line; narrower rs specialist list preserved)
+  - .claude/rules/security.md                                                # MERGE (rs variant — +Sanitizer Contract display-hygiene section + Multi-Site Kwarg Plumbing section; Rust Credential Comparison + Fail-Closed Defaults + Network Transport Hardening preserved)
+  - .claude/rules/framework-first.md                                         # MERGE (rs variant — +Framework Version-Stable Integration 'Drive The Data, Not The Dispatch' section; binding-focused anti-pattern table preserved)
+  - .claude/VERSION                                                          # UPDATED (2.9.7 → 2.9.8; upstream 2.8.18 → 2.8.19; synced_at refreshed; sdk_packages unchanged at 3.18.0)
   - .claude/.coc-sync-marker                                                 # UPDATED
 not_applied: []
 unchanged_skipped:
-  - All other artifacts (single-file delivery from loom 2.8.18 source)
+  - agents/*, skills/*, commands/*, scripts/hooks/* (no changes in loom 2.8.19)
+  - CLAUDE.md (NEVER overwritten — preserved)
+  - .claude/settings.local.json (NEVER overwritten — preserved)
 sdk_pins:
-  kailash-enterprise: ">=3.18.0"                                             # UNCHANGED (no Cargo change)
+  kailash-enterprise: ">=3.18.0"                                             # UNCHANGED (no rs release between 2.9.6 and 2.9.8; rs Cargo workspace remains at 3.18.0)
 proposal_distributed:
-  note: "Loom-side correction, not BUILD-driven. No proposal status transition."
+  note: "py Gate 2 already marked the proposal as distributed; rs Gate 2 is a consumer of the same round. No proposal status transition here."
 hooks_verified:
   count: 12/12
-  note: "Unchanged from 2.9.6 sync."
+  note: "All 12 registered hook paths in settings.json resolve to .js files on disk. validate-prod-deploy.js is on disk but unregistered (intentional)."
+rs_variant_notes:
+  - "variants/py/* NOT applied to rs target (per guardrails)"
+  - "3 of 7 synced files (security.md, agents.md, framework-first.md) have rs variants in loom sync-manifest.yaml. New 2.8.19 sections merged INTO existing rs variants, not overwrites — preserves rs-variant content (Rust security clauses, narrower specialist list, binding anti-pattern table). USE-specific adaptations called out in VERSION changelog."
+  - "orphan-detection.md Rule 6 uses Python __all__ examples. Shipped as-is to rs template because sync-manifest.yaml lines 60-63 declare rs variant = Python examples (Python/Ruby binding consumers, NOT Rust developers)."
+build_repo_changes: []

--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,14 +1,14 @@
 {
-  "version": "2.9.7",
+  "version": "2.9.8",
   "type": "coc-use-template",
   "description": "COC USE template for Python/Ruby developers using Rust-backed Kailash bindings",
   "released": "2026-04-19",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "2.8.18",
+    "version": "2.8.19",
     "build_version": "3.18.0",
-    "synced_at": "2026-04-19T11:15:00Z",
+    "synced_at": "2026-04-19T14:30:00Z",
     "sdk_packages": {
       "kailash-value": "3.18.0",
       "kailash-core": "3.18.0",
@@ -61,6 +61,23 @@
     }
   },
   "changelog": [
+    {
+      "version": "2.9.8",
+      "date": "2026-04-19",
+      "summary": "Sync loom 2.8.19 \u2014 7 global rule extensions from kailash-py round-10 post-release audit codify (cross-SDK, language-agnostic patterns). No rs SDK release; Cargo pins unchanged (3.18.0).",
+      "changes": [
+        "EXTENDED: rules/tenant-isolation.md \u2014 +Rule 3a 'Keyspace Version Bumps Require Invalidation-Path Sweep' (CRITICAL). When CacheKeyGenerator default version bumps (v1\u2192v2), every invalidation entry point MUST use a version-wildcard pattern (`dataflow:v*:...`) to sweep both legacy and current keys. BLOCKED rationalizations + origin (kailash-py PR #522/#529 fast-patch, dataflow 2.0.12).",
+        "EXTENDED: rules/security.md \u2014 +'Sanitizer Contract \u2014 DataFlow Display Hygiene' section (3 sub-rules: token-replace not quote-escape, type-confusion MUST raise, safe types pass through) + 'Multi-Site Kwarg Plumbing' section (security-relevant kwargs plumbed through helpers MUST be updated at every call site in the same PR). Rs-variant Rust clauses (Credential Comparison, Fail-Closed Defaults, Network Transport Hardening) preserved.",
+        "EXTENDED: rules/orphan-detection.md \u2014 +Rule 6 'Module-Scope Public Imports Appear In __all__' (HIGH). Any symbol imported at module-scope into a package's __init__.py MUST appear in __all__. Evidence: kailash-ml 0.11.0 eagerly imported DeviceReport + device_report_from_backend_info + device + use_device but omitted all four from __all__; patched in 0.11.1. USE-NOTE: Python-specific __all__ pattern. The rs USE template serves Python/Ruby binding consumers per sync-manifest.yaml lines 60-63, so Python examples land correctly.",
+        "EXTENDED: rules/cross-sdk-inspection.md \u2014 +\u00a73a 'Structural API-Divergence Disposition' (when sibling SDKs diverge structurally, close ticket with BOTH Tier-2 binding-path test + signature-invariant test, same PR; `Python doesn't have this API` closures are BLOCKED) + \u00a75 'Cross-SDK Symbol Citations MUST Be Grep-Verified' (every concrete symbol cited across SDKs verified against working tree before commit; evidence in commit body). Origin: kailash-py issue #525 / PR #528.",
+        "EXTENDED: rules/dependencies.md \u2014 +'Phantom Transitive Deps \u2014 Resolve Via Lockfile Upgrade, Not Local Caps' section (multi-ecosystem: uv + cargo + npm). Phantom transitive dep (installed by lockfile, zero-imports) holding a secondary package at an old cap MUST be resolved by `uv lock --upgrade-package X` / `cargo update -p X`, NOT by manifest-level caps. Origin: kailash-py PR #530 \u2014 google-generativeai 0.8.6 phantom blocked protobuf upgrade; dropped cleanly.",
+        "EXTENDED: rules/agents.md \u2014 Quality Gates table +'After release (post-merge audit)' row (RECOMMENDED reviewer run against merged main; if CRIT/HIGH surfaces, patch branch in SAME session and ship as x.y.z+1) + 'Verify Agent Deliverables Exist After Exit' section (parent orchestrator MUST ls/Read claimed files before trusting agent completion; budget-exhaustion-mid-message truncates final writes). Rs-variant narrower specialist list preserved.",
+        "EXTENDED: rules/framework-first.md \u2014 +'Framework Version-Stable Integration \u2014 Drive The Data, Not The Dispatch' section. Integrations MUST iterate registered-handlers data structure (on_startup / on_shutdown lists) NOT call dispatch method by name (startup() / shutdown()); dispatch names drift across framework versions. Origin: kailash-py issue #531 / PR #533 \u2014 kailash-nexus 2.1.0 crashed at uvicorn lifespan because FastAPI exposed only _startup; 2.1.1 fix iterated on_startup list. Rs-variant binding-focused anti-pattern table preserved.",
+        "PIN: Cargo workspace unchanged (3.18.0). No rs SDK release in this cycle; pyproject.toml kailash-enterprise>=3.18.0 unchanged.",
+        "HOOKS: 12/12 registered settings.json hooks exist on disk.",
+        "RS VARIANT NOTE: 3 of 7 files (security.md, agents.md, framework-first.md) have rs variants per sync-manifest.yaml. New 2.8.19 sections were MERGED into the existing rs variants (not overwrites) to preserve rs-variant content: Rust security clauses, narrower specialist list, binding-focused anti-pattern table. The 4 no-rs-variant files (tenant-isolation, orphan-detection, cross-sdk-inspection, dependencies) overwritten from global as-is."
+      ]
+    },
     {
       "version": "2.9.7",
       "date": "2026-04-19",
@@ -626,5 +643,5 @@
       ]
     }
   ],
-  "updated": "2026-04-19T11:15:00Z"
+  "updated": "2026-04-19T14:30:00Z"
 }

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -43,14 +43,15 @@ Reviews happen at COC phase boundaries, not per-edit. Skip only when explicitly 
 
 **Why:** Skipping gate reviews lets analysis gaps, security holes, and naming violations propagate to downstream repos where they are far more expensive to fix. Evidence: 0052-DISCOVERY §3.3 — six commits shipped without a single review because gates were phrased as "recommended." Upgrading to MUST + background agents makes reviews nearly free.
 
-| Gate                | After Phase  | Enforcement | Review                                                                         |
-| ------------------- | ------------ | ----------- | ------------------------------------------------------------------------------ |
-| Analysis complete   | `/analyze`   | RECOMMENDED | **reviewer**: Are findings complete? Gaps?                                     |
-| Plan approved       | `/todos`     | RECOMMENDED | **reviewer**: Does plan cover requirements?                                    |
-| Implementation done | `/implement` | **MUST**    | **reviewer** + **security-reviewer**: Run as parallel background agents.       |
-| Validation passed   | `/redteam`   | RECOMMENDED | **reviewer**: Are red team findings addressed?                                 |
-| Knowledge captured  | `/codify`    | RECOMMENDED | **gold-standards-validator**: Naming, licensing compliance.                    |
-| Before release      | `/release`   | **MUST**    | **reviewer** + **security-reviewer** + **gold-standards-validator**: Blocking. |
+| Gate                             | After Phase          | Enforcement | Review                                                                                                                                                                                                                                                                                         |
+| -------------------------------- | -------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Analysis complete                | `/analyze`           | RECOMMENDED | **reviewer**: Are findings complete? Gaps?                                                                                                                                                                                                                                                     |
+| Plan approved                    | `/todos`             | RECOMMENDED | **reviewer**: Does plan cover requirements?                                                                                                                                                                                                                                                    |
+| Implementation done              | `/implement`         | **MUST**    | **reviewer** + **security-reviewer**: Run as parallel background agents.                                                                                                                                                                                                                       |
+| Validation passed                | `/redteam`           | RECOMMENDED | **reviewer**: Are red team findings addressed?                                                                                                                                                                                                                                                 |
+| Knowledge captured               | `/codify`            | RECOMMENDED | **gold-standards-validator**: Naming, licensing compliance.                                                                                                                                                                                                                                    |
+| Before release                   | `/release`           | **MUST**    | **reviewer** + **security-reviewer** + **gold-standards-validator**: Blocking.                                                                                                                                                                                                                 |
+| After release (post-merge audit) | `/release` follow-up | RECOMMENDED | **reviewer** run against the MERGED release commit on main. Catches drift that pre-release review missed (e.g., a kwarg plumbing gap in a sibling call site, a keyspace bump with a missed invalidator). If CRIT/HIGH surfaces, open a patch branch in the SAME session and ship as `x.y.z+1`. |
 
 **BLOCKED responses when skipping MUST gates:**
 
@@ -89,6 +90,31 @@ Agent(prompt: "implement feature Y...")  # Blocks waiting for X's build lock
 ```
 
 **Why:** Cargo uses an exclusive filesystem lock on `target/`. Two cargo processes in the same directory serialize completely, turning parallel agents into sequential execution. Worktrees give each agent its own `target/` directory.
+
+**See `rules/worktree-isolation.md`** for the orchestrator pinning contract, the specialist self-check, and the post-agent file-existence verification. The `isolation: "worktree"` flag is necessary but not sufficient — without the verification layer, agents drift back to the main checkout silently.
+
+## MUST: Verify Agent Deliverables Exist After Exit
+
+When an agent reports completion of a file-writing task, the parent orchestrator MUST `ls` or `Read` the claimed file before trusting the completion claim. Agent "done" messages are NOT evidence of file creation — budget exhaustion mid-message truncates the final write, and the agent emits "Now let me write X..." with no tool call behind it.
+
+```python
+# DO — verify
+result = Agent(prompt="Write src/feature.py with ...")
+# parent's next step:
+Read("/abs/path/src/feature.py")  # raises if missing → retry
+
+# DO NOT — trust the completion message
+result = Agent(prompt="Write src/feature.py with ...")
+# parent moves on; src/feature.py never existed
+```
+
+**BLOCKED rationalizations:**
+
+- "The agent said 'done', that's good enough"
+- "Verifying every file slows the orchestrator"
+- "Now let me write the file…" (with no subsequent tool call)
+
+**Why:** Multi-agent sessions log occurrences where an agent hits its budget mid-message and reports success with zero files on disk. The `ls` check is O(1) and converts silent no-op into loud retry. See `rules/worktree-isolation.md` MUST Rule 3 for the full protocol.
 
 ## MUST NOT
 

--- a/.claude/rules/cross-sdk-inspection.md
+++ b/.claude/rules/cross-sdk-inspection.md
@@ -50,6 +50,45 @@ Per EATP SDK conventions (D6: independent implementation, matching semantics):
 
 **Why:** Semantic divergence between SDKs means code ported from Python to Rust (or vice versa) silently changes behavior, breaking user trust in the platform's cross-language promise.
 
+### 3a. Structural API-Divergence Disposition
+
+When the sibling SDK reports a bug at an API surface that this SDK does not expose (e.g. kailash-rs#424 `execute_raw(sql, params)` vs kailash-py `execute_raw(sql)`), the disposition MUST include BOTH of the following in the same PR:
+
+1. A **Tier 2 test through the sibling-binding path** that exercises the real surface this SDK uses (e.g. Python Express `bulk_create` with shrinking-arity test matrix) to prove the issue does not reproduce here.
+2. A **structural-invariant test locking the signature** — a test that asserts the current signature arity / kwarg shape / return type, so a future refactor toward the sibling SDK's shape fails loudly at test time rather than silently reopening the divergence.
+
+```python
+# DO — close the issue with both tests landed in the same PR
+@pytest.mark.integration
+async def test_execute_raw_sibling_binding_does_not_reproduce(db):
+    # Exercises the real Express bulk_create path that kailash-rs#424 hit
+    for batch_size in (1, 10, 100, 1000):
+        rows = [{"id": i, "x": i} for i in range(batch_size)]
+        await db.express.bulk_create("Row", rows)
+
+def test_execute_raw_signature_invariant():
+    """Lock the arity: Python's execute_raw takes (sql) only, not (sql, params)."""
+    import inspect
+    sig = inspect.signature(AsyncSQLDatabaseNode.execute_raw)
+    positional = [p for p in sig.parameters.values() if p.kind != inspect.Parameter.VAR_KEYWORD]
+    assert len(positional) == 2, "execute_raw(self, sql) — do not add params positional"
+
+# DO NOT — close the sibling issue with a "not applicable" comment only
+# gh issue close kailash-py#525 --comment "Python doesn't expose execute_raw(sql, params); closing"
+# ↑ no test guards against a future refactor silently adding params; the divergence reopens invisibly
+```
+
+**BLOCKED rationalizations:**
+
+- "Python doesn't have this API, so nothing to test"
+- "The sibling tested it, we don't need to"
+- "A structural test is over-engineering for a one-line divergence"
+- "We'll add the guard when someone tries to reshape the API"
+
+**Why:** "Not applicable" closes the ticket but leaves zero structural defense against a future refactor that drifts toward the sibling shape; the binding-path Tier 2 test proves the bug doesn't reproduce today, and the signature-invariant test proves it cannot reproduce tomorrow by a silent API change. Together they convert "closed without test" (the prior failure mode) into two grep-able assertions that survive every refactor.
+
+Origin: kailash-py issue #525 / PR #528 (2026-04-19) — closed a structural cross-SDK divergence ticket with two tests (binding-path + signature invariant) rather than a "not applicable" comment.
+
 ### 4. Inspection Checklist
 
 When closing any issue, verify:
@@ -60,6 +99,54 @@ When closing any issue, verify:
 - [ ] Cross-reference added to both issues if applicable
 
 **Why:** Closing without cross-SDK verification is the primary cause of feature drift — the checklist is the last gate before an issue is forgotten.
+
+### 5. Cross-SDK Symbol Citations MUST Be Grep-Verified
+
+When a template, skill, rule, or guide authored in one BUILD repo cites a concrete symbol from the sibling SDK (an import path, class name, method name, error type, env var name, or file path), the citation MUST be verified against the sibling SDK's working tree BEFORE the commit lands. If the symbol cannot be confirmed to exist, cite the abstract pattern instead — never invent the literal API.
+
+Evidence of verification MUST appear in the commit body in the following format:
+
+```
+Verified against kailash-py:
+- DialectManager.get_dialect → packages/kailash-dataflow/src/dataflow/adapters/dialect.py:446
+- InvalidIdentifierError → packages/kailash-dataflow/src/dataflow/adapters/exceptions.py
+```
+
+```python
+# DO — cite a verified Python symbol from a kailash-py-targeted skill
+# (grep confirmed: DialectManager.get_dialect exists at the cited path)
+from dataflow.adapters.dialect import DialectManager
+from dataflow.adapters.exceptions import InvalidIdentifierError
+
+dialect = DialectManager.get_dialect("postgresql")
+```
+
+```rust
+// DO — cite a verified Rust symbol from a kailash-rs-targeted artifact
+// (grep confirmed: BlockingFinalizerProtector exists at the cited path)
+use kailash_core::runtime::BlockingFinalizerProtector;
+```
+
+```markdown
+# DO NOT — cite a symbol whose existence in the sibling SDK was not grep-checked
+
+A kailash-py rule references `BlockingFinalizerProtector` from kailash-rs as a
+recommended pattern — but a grep against the kailash-rs working tree returns
+zero matches. The cited symbol does not exist; the rule recommends a phantom API.
+```
+
+**BLOCKED rationalizations:**
+
+- "The API looks like it should exist"
+- "The name is standard Python / standard Rust"
+- "The skill describes intent, not literal API"
+- "We'll verify later"
+- "The sibling SDK is on the roadmap to add this"
+- "The example is illustrative, not load-bearing"
+
+**Why:** Cross-SDK citations that are not grep-verified produce phantom APIs that downstream consumers wire into their code, only to discover at runtime that the cited symbol never existed. The bug-fix-side cross-SDK rule (MUST Rules 1–4 above) covers issue inspection; this rule covers the more common template / skill / rule authorship path, where invented APIs are even harder to detect because they look plausible. Single-grep verification at authorship time costs seconds and prevents the multi-session debugging cost that "I'll verify later" guarantees.
+
+Origin: kailash-rs codify cycle (2026-04-19) — multiple cross-SDK API miscitations in skill authorship surfaced as HIGH red-team findings; precedent in earlier `kailash-coc-claude-rs#52` (Bedrock preset cited before SDK shipped).
 
 ## Examples
 

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -287,3 +287,33 @@ cargo check --quiet
 ```
 
 Any unmet, missing, or conflicting dependency BLOCKS the gate.
+
+## Phantom Transitive Deps — Resolve Via Lockfile Upgrade, Not Local Caps
+
+When `pip check` / `cargo tree -d` / `npm ls` reports a conflict whose root is an unused transitive dependency, the fix MUST be to let the solver drop the orphan (`uv lock --upgrade-package X` + `uv sync`, `cargo update -p X`, `npm update X`). Adding a local cap / pin on a package this project does not directly import is BLOCKED.
+
+```bash
+# DO — Python: let uv drop the orphan transitive
+uv lock --upgrade-package google-generativeai   # solver re-resolves; orphan drops
+uv sync                                         # lockfile + venv converge
+pip check                                       # clean
+
+# DO — Rust: cargo update drops the orphan
+cargo update -p some-transitive-crate
+
+# DO NOT — pin the orphan in the manifest
+# pyproject.toml:
+# dependencies = [..., "protobuf>=4.0,<5.0"]  # we don't import protobuf; this is speculative
+```
+
+**BLOCKED rationalizations:**
+
+- "The lockfile solver might not find a clean resolution"
+- "A local cap is faster than re-resolving the lockfile"
+- "We'll remove the cap later"
+- "The transitive is 'required-recommended' even though we don't import it"
+- "Capping is safer than trusting the upstream compat range"
+
+**Why:** A phantom transitive dep — one installed by the lockfile but zero-imports in the project — that holds a secondary package at an old cap is a solver trap: every upgrade of the actually-imported deps is blocked by the phantom's constraint. Pinning at the manifest level locks the trap in permanently; the only fix that keeps the solver free is `uv lock --upgrade-package` / `cargo update -p` / `npm update` which lets the resolver drop the phantom when it's no longer required by any imported package. Manifest-level caps on unimported packages also silently violate `§ No Caps on Transitive Dependencies` above.
+
+Origin: kailash-py PR #530 (2026-04-19) — `google-generativeai 0.8.6` was installed by the lockfile with zero imports in the project, holding `protobuf` at an old cap that blocked the `kailash-align 0.3.2` release. Fix: `uv lock --upgrade-package google-generativeai` dropped it cleanly, protobuf upgraded, release unblocked.

--- a/.claude/rules/framework-first.md
+++ b/.claude/rules/framework-first.md
@@ -102,3 +102,39 @@ conn.execute("INSERT INTO users (name, email) VALUES (%s, %s)", (name, email))
 ```
 
 **Why:** Without a mandatory specialist gate, agents default to the pattern they know (raw SQL, raw HTTP) rather than the framework pattern they should learn. This is the single highest-leverage fix for the "bypass DataFlow and directly connect" failure mode.
+
+## Framework Version-Stable Integration — Drive The Data, Not The Dispatch
+
+When integrating with an external framework's lifecycle hook (FastAPI / Starlette lifespan, aiohttp on_startup, Rails initializer, Rack middleware), if the framework exposes BOTH (a) a dispatch method name AND (b) a list/dict of registered handlers, the data structure is the stable surface across versions. Dispatch method names drift — underscore-prefix transitions, removal, renames — the registration list is what the framework's own internal dispatcher iterates.
+
+Integrations MUST iterate the registered-handlers data structure, NOT call the dispatch method by name.
+
+```python
+# DO — iterate the on_startup / on_shutdown list (what FastAPI's _DefaultLifespan does internally)
+@asynccontextmanager
+async def lifespan(app):
+    for handler in app.router.on_startup:
+        await handler() if inspect.iscoroutinefunction(handler) else handler()
+    yield
+    for handler in app.router.on_shutdown:
+        await handler() if inspect.iscoroutinefunction(handler) else handler()
+
+# DO NOT — call the dispatch method by name
+@asynccontextmanager
+async def lifespan(app):
+    await app.router.startup()   # AttributeError on builds where only _startup exists
+    yield
+    await app.router.shutdown()  # same drift hazard
+```
+
+**BLOCKED rationalizations:**
+
+- "The method name has been stable for years"
+- "The framework's docs show the method-name form"
+- "We'll pin the framework version to avoid the drift"
+- "The list form is an internal detail, we should use the public API"
+- "If the method is renamed, we'll rename our call"
+
+**Why:** Framework-integration code runs in every production instance; a single `AttributeError` on a renamed dispatch method crashes every service at lifespan boot with zero type-checker signal. The registered-handlers list is the data the framework's OWN internal dispatcher iterates — it cannot be removed without breaking the framework's own hooks, so it is strictly more stable than any dispatch method name. "Pin the framework version" is an anti-pattern: it creates a treadmill where every dependency upgrade re-triggers the same failure mode. Drive the data; don't call the dispatch.
+
+Origin: kailash-py issue #531 / PR #533 (2026-04-19) — kailash-nexus 2.1.0 called `app.router.startup()` / `.shutdown()` as if stable across FastAPI versions; some production FastAPI builds exposed only `_startup`; every 2.1.0 service crashed at uvicorn lifespan. Fix (2.1.1): iterate the `on_startup` / `on_shutdown` lists directly.

--- a/.claude/rules/orphan-detection.md
+++ b/.claude/rules/orphan-detection.md
@@ -149,6 +149,47 @@ Any PR that removes a public symbol (module, class, function, attribute) MUST de
 
 **Why:** Collection failures are invisible in "unit-only CI" setups yet become merge-blocking the moment someone runs the full suite locally. The only way to keep the full suite runnable is to gate every PR on collect-only-green.
 
+### 6. Module-Scope Public Imports Appear In `__all__`
+
+When a symbol is imported at module-scope into a package's `__init__.py` (not behind `_` / not lazy via `__getattr__`), it MUST appear in that module's `__all__` list unless the symbol itself is private (leading underscore). New `__all__` entries MUST land in the same PR as the import. Eagerly-imported-but-absent-from-`__all__` is BLOCKED.
+
+```python
+# DO — every public module-scope import appears in __all__
+# pkg/__init__.py
+from pkg._device_report import (
+    DeviceReport,
+    device_report_from_backend_info,
+)
+
+__all__ = [
+    "__version__",
+    "DeviceReport",
+    "device_report_from_backend_info",
+    ...
+]
+
+# DO NOT — public symbol imported but missing from __all__
+from pkg._device_report import DeviceReport, device_report_from_backend_info
+
+__all__ = [
+    "__version__",
+    # DeviceReport, device_report_from_backend_info → absent
+    # Result: `from pkg import *` drops the advertised public API
+]
+```
+
+**BLOCKED rationalizations:**
+
+- "The symbol is reachable via `pkg.DeviceReport`, that's enough"
+- "Nobody uses `from pkg import *`"
+- "`__all__` is a convention, not a contract"
+- "We'll clean up `__all__` in a follow-up"
+- "The symbol is eagerly imported; the package re-exports it implicitly"
+
+**Why:** `__all__` is the package's public-API contract: documentation generators (Sphinx autodoc), linters, typing tools (`mypy --strict`), and `from pkg import *` consumers all read it as the canonical export list. A symbol that is "eagerly imported" but never listed is both advertised (via the import) AND hidden (via `__all__`) — that inconsistency is the exact failure shape the orphan pattern produces on the consumer side. The fix is a one-line addition in the same PR; deferring it means the advertised feature ships broken for every tool that respects `__all__`.
+
+Origin: kailash-py PR #523 / PR #529 (2026-04-19) — kailash-ml 0.11.0 eagerly imported `DeviceReport` / `device_report_from_backend_info` / `device` / `use_device` but omitted all four from `__all__`; caught by post-release reviewer; patched in 0.11.1.
+
 ## MUST NOT
 
 - Land a `db.X` / `app.X` facade without the production call site in the same PR

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -119,6 +119,94 @@ All user-generated content MUST be encoded before display in HTML templates, JSO
 
 **Why:** Once committed, secrets persist in git history even after removal, and are exposed to anyone with repo access.
 
+## Sanitizer Contract — DataFlow Display Hygiene
+
+DataFlow's input sanitizer (`packages/kailash-dataflow/src/dataflow/core/nodes.py::sanitize_sql_input`) is a defense-in-depth display-path safety net, NOT the primary SQLi defense. Parameter binding (`$N` / `%s` / `?`) is the primary defense — see § Parameterized Queries above.
+
+The sanitizer's contract is fixed:
+
+### 1. String Inputs MUST Be Token-Replaced, Not Quote-Escaped
+
+For declared-string fields, the sanitizer MUST replace dangerous SQL keyword sequences with grep-able sentinel tokens (`STATEMENT_BLOCKED`, `DROP_TABLE`, `UNION_SELECT`, etc.). Quote-escaping (`'` → `''`) is BLOCKED.
+
+```python
+# DO — token-replace produces grep-able audit trail
+"'; DROP TABLE users; --" → "'; STATEMENT_BLOCKED users; -- COMMENT_BLOCKED"
+
+# DO NOT — quote-escape: the payload survives in storage
+"'; DROP TABLE users; --" → "''; DROP TABLE users; --"
+```
+
+**Why:** Token-replace makes attacker intent grep-able post-incident (`grep STATEMENT_BLOCKED audit.log`). Quote-escape preserves the payload as data, masking that an attack was attempted. The actual injection defense is parameter binding; the sanitizer is the audit trail.
+
+### 2. Type-Confusion MUST Raise, Not Silently Coerce
+
+For declared-string fields receiving `dict` / `list` / `set` / `tuple` values, the sanitizer MUST raise `ValueError("parameter type mismatch: …")`. Silent coercion via `str(value)` is BLOCKED — it lets a nested structure bypass the string-only sanitizer.
+
+```python
+# DO — type-confusion is rejected at the validate_inputs gate
+if declared_type is str and isinstance(value, (dict, list, set, tuple)):
+    raise ValueError(
+        f"parameter type mismatch: field '{field_name}' declared as 'str' "
+        f"but received '{type(value).__name__}' — type confusion blocked"
+    )
+
+# DO NOT — silent str() coercion
+value = str(value)  # {"x": "'; DROP TABLE"} becomes "{'x': \"'; DROP TABLE\"}"
+# ↑ the dict's contents get sanitized as a string but the original
+#   structure already left the validation boundary
+```
+
+**Why:** A malicious upstream node that passes `{"injection": "'; DROP TABLE …"}` for a field declared as `str` bypasses every string-only check. Raising at the type-confusion boundary closes the bypass; coercion-to-string converts a structural attack into an unaudited storage event.
+
+### 3. Safe Types Are Returned As-Is
+
+Values of declared-safe types (`int`, `float`, `bool`, `Decimal`, `datetime`, `date`, `time`) MUST pass through unchanged. `dict` and `list` MUST also pass through unchanged when the field's declared type is `dict` or `list` (JSON / array columns). Bug #515 documents this: premature `json.dumps()` on dict/list breaks parameter binding in `AsyncSQLDatabaseNode`.
+
+**BLOCKED rationalizations:**
+
+- "Token-replace is weaker than quote-escape, we should switch"
+- "We should silently coerce dict to JSON for safety"
+- "Type-confusion is an upstream concern, not the sanitizer's job"
+- "The integration tests can catch these"
+
+Origin: GitHub issues #492 (bulk_upsert SQLi via string-escape) + #493 (sanitizer contract drift, 3 pre-existing failing tests). The contract above pins the decision so a future refactor doesn't swing back to quote-escape.
+
+## Multi-Site Kwarg Plumbing
+
+When a security-relevant kwarg (classification policy, tenant scope, clearance context, audit correlation ID) is plumbed through a helper, EVERY call site of that helper MUST be updated in the SAME PR. Updating the "primary" call site and deferring siblings is BLOCKED.
+
+```python
+# DO — grep every caller, update every sibling, same PR
+# Helper added `policy` + `model_name` kwargs for classification sanitisation.
+#
+# $ grep -rn 'validate_model(' src/ packages/
+# packages/kailash-dataflow/src/dataflow/features/express.py:_validate_if_enabled
+# packages/kailash-dataflow/src/dataflow/engine.py::validate_record
+#
+# Both production call sites get policy+model_name in this PR:
+engine.validate_record(instance) -> validate_model(instance, policy=..., model_name=...)
+express._validate_if_enabled(...) -> validate_model(instance, policy=..., model_name=...)
+
+# DO NOT — update primary site, skip the sibling
+express._validate_if_enabled(...) -> validate_model(instance, policy=..., model_name=...)
+engine.validate_record(instance)  -> validate_model(instance)   # bypasses sanitiser
+# ↑ The unpatched sibling surface still leaks classified field names / values in
+#   error messages; the sanitisation contract is broken on one public entry point.
+```
+
+**BLOCKED rationalizations:**
+
+- "The primary call site is the one users hit 99% of the time"
+- "The sibling is rarely used; we'll patch it in a follow-up"
+- "The helper signature is backwards-compatible, sibling can stay as-is"
+- "Test coverage will catch divergence later"
+- "The kwarg has a safe default — siblings still get baseline behaviour"
+
+**Why:** A helper that takes a security-relevant kwarg has the kwarg precisely because the unqualified call leaks or misbehaves. Leaving any sibling call site on the unqualified signature ships the exact failure mode the kwarg was introduced to fix; the "safe default" is by definition the insecure default (otherwise the kwarg would not exist). The fix is mechanical — `grep -rn 'helper_name(' .` and patch every hit in the same PR.
+
+Origin: kailash-py PR #522 / PR #529 (2026-04-19) — BP-049 validation sanitiser `validate_model(policy=..., model_name=...)` landed in Express site but `DataFlowEngine.validate_record` was left unqualified; post-release reviewer caught it; fast-patched in dataflow 2.0.12.
+
 ## Kailash-Specific Security
 
 - **DataFlow**: Access controls on models, validate at model level, never expose internal IDs

--- a/.claude/rules/tenant-isolation.md
+++ b/.claude/rules/tenant-isolation.md
@@ -82,6 +82,34 @@ async def invalidate_model(self, model: str) -> int:
 
 **Why:** A user invalidating "their" cache should not clear every other tenant's cache. Tenant-scoped invalidation also enables targeted cache busting on tenant-specific events (a single tenant's password rotation, a single tenant's quota change).
 
+### 3a. Keyspace Version Bumps Require Invalidation-Path Sweep
+
+When the default keyspace version emitted by `CacheKeyGenerator` (or equivalent key-constructor) is bumped — e.g. `v1 → v2` for a cross-SDK parity change or a classification-hash format change — EVERY invalidation entry point in the codebase MUST be audited and updated in the same PR. The safest disposition is to match the version segment as a wildcard (`dataflow:v*:*`) so legacy keys AND current keys are swept in one call.
+
+```python
+# DO — version-wildcard sweep, future-proof
+if tenant_id is not None:
+    express_pattern = f"dataflow:v*:{tenant_id}:{model_name}:*"
+else:
+    express_pattern = f"dataflow:v*:{model_name}:*"
+query_pattern = f"dataflow:{model_name}:v*:*"
+
+# DO NOT — version-pinned sweep after the generator bumps
+express_pattern = f"dataflow:v1:{model_name}:*"   # misses every v2 entry
+query_pattern = f"dataflow:{model_name}:v1:*"
+```
+
+**BLOCKED rationalizations:**
+
+- "The invalidation path runs rarely, v1 entries will expire on their own TTL"
+- "We'll update the invalidation in a follow-up PR"
+- "The generator default can be reverted if it causes issues"
+- "Only one adapter pins the old version; the others are fine"
+
+**Why:** A cache keyspace bump is a producer-side change that silently breaks every consumer-side invalidator pinned to the old version. Write-then-invalidate leaves stale entries on the shared backend (Redis, Memcached, etc.) indefinitely; TTL-based eventual-expiry is not a substitute because TTLs are often multi-hour and users observe the stale reads in the meantime. Version-wildcard sweeps are the structural defense — the only invalidation code that survives the next keyspace bump unchanged.
+
+Origin: kailash-py PR #522 / PR #529 (2026-04-19) — BP-049 keyspace bump `v1→v2`; Redis invalidator missed in the producer-side update, caught by post-release reviewer, fast-patched in dataflow 2.0.12.
+
 ### 4. Metric Labels Carry Tenant_id (Bounded)
 
 Metrics that count per-tenant operations (`requests_total`, `cache_hits_total`, `errors_total`) MAY include `tenant_id` as a label, BUT label cardinality MUST be bounded. Unbounded `tenant_id` labels in Prometheus produce a metric series per tenant which exhausts memory at scale.


### PR DESCRIPTION
## Summary

Single-cycle cross-SDK catch-up. Same 7 rule extensions the py template received in 3.5.7 (kailash-py round-10 post-release audit codify), applied to rs template per loom global scope. Patterns are language-agnostic.

## 7 rule extensions

| Rule | Extension | Notes |
|---|---|---|
| `tenant-isolation.md` | +Rule 3a Keyspace Version Bumps Require Invalidation-Path Sweep | Overwrite (no rs variant) |
| `security.md` | +Multi-Site Kwarg Plumbing | **Merge** — preserves rs Rust clauses (Credential Comparison, Fail-Closed Defaults, Network Transport Hardening) |
| `orphan-detection.md` | +Rule 6 `__all__` Hygiene | Python-specific pattern. rs USE template targets Python/Ruby binding consumers per manifest convention so Python examples land correctly |
| `cross-sdk-inspection.md` | +§3a Structural API-Divergence Disposition | Overwrite |
| `dependencies.md` | +Phantom Transitive Deps | Multi-ecosystem — Rust `Cargo.lock` variant with `cargo update -p` already covered |
| `agents.md` | +post-release audit row + Verify Deliverables | **Merge** — rs narrower specialist list preserved (no mcp-platform-specialist) |
| `framework-first.md` | +Drive The Data Not The Dispatch | **Merge** — rs binding-focused anti-pattern table preserved |

## SDK pins

- **Unchanged** — `kailash-enterprise >= 3.18.0`. No kailash-rs release between 2.9.7 and 2.9.8.

## Cross-SDK origins (from kailash-py session 2026-04-19)

- CRITICAL: PR #522/#529 cache v1→v2 bump invalidator drift
- HIGH: BP-049 validate_model kwarg plumbing miss
- HIGH: kailash-ml 0.11.0 `__all__` hygiene
- HIGH: kailash-nexus 2.1.0 FastAPI dispatch drift (#531/#533)
- MEDIUM: cross-SDK #525 structural divergence
- MEDIUM: uv/cargo/npm phantom transitive deps

These are cross-SDK principles — the kailash-rs BUILD repo has 5 parallel tickets queued (keyspace sweep, multi-site kwarg, structural divergence, Cargo phantom deps, nexus-rs dispatch) for its next codify cycle.

## Test plan

- [x] 7 rule files updated via `coc-sync` agent
- [x] Hooks 12/12 resolve on disk
- [x] Variant overlay verified (variants/py NOT applied to rs target)
- [x] Merge strategy for 3 files with rs variants (security, agents, framework-first) — preserved rs-specific clauses
- [x] `.claude/VERSION` updated in-place
- [x] No BUILD repo changes

## Related

- Source: `esperie-enterprise/loom@c26de7d` (loom 2.8.19)
- BUILD: `esperie/kailash-rs` v3.18.0 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)