### PR TITLE
fix(coc): track .claude/hooks/lib/ in git (2.9.16)

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,8 +1,8 @@
 {
-  "version": "2.9.15",
+  "version": "2.9.16",
   "type": "coc-use-template",
   "description": "COC USE template for Python/Ruby developers using Rust-backed Kailash bindings",
-  "released": "2026-04-26",
+  "released": "2026-04-27",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
@@ -61,6 +61,15 @@
     }
   },
   "changelog": [
+    {
+      "version": "2.9.16",
+      "date": "2026-04-27",
+      "summary": "PATCH: track .claude/hooks/lib/ in git. Prior .gitignore had `lib/` ignore with whitelist pinned to the legacy `scripts/hooks/lib/` path, leaving the v2.9.x canonical `.claude/hooks/lib/` payload (7 sibling modules: env-utils, learning-utils, workspace-utils, version-utils, release-drift, runtime, template-resolver) untracked. Downstream consumers that cloned post-v2.9.0 saw an empty `.claude/hooks/lib/` dir; CC startup hooks crashed with 'Cannot find module ./lib/<sibling>'. Fix: replaced `!scripts/hooks/lib/` whitelist with `!.claude/hooks/lib/` (legacy `scripts/hooks/` is obsoleted via .coc-obsoleted from v2.9.1).",
+      "changes": [
+        "GLOBAL .gitignore: removed `!scripts/hooks/lib/` whitelist (legacy path obsoleted); added `!.claude/hooks/lib/` so the v2.9.x sibling modules are tracked.",
+        "GLOBAL .claude/hooks/lib/: first commit of the 7 sibling modules to git history. Files have been on working tree since v2.9.0 sync but were masked from `git add` by the gitignore."
+      ]
+    },
     {
       "version": "2.9.15",
       "date": "2026-04-26",

--- a/.claude/hooks/lib/env-utils.js
+++ b/.claude/hooks/lib/env-utils.js
@@ -1,0 +1,284 @@
+/**
+ * Shared utility: Environment variable parsing and model-key validation.
+ *
+ * Used by session-start.js, validate-workflow.js, and user-prompt-rules-reminder.js.
+ * Framework-agnostic — works with any Kailash project.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// =========================================================================
+// Model → Provider → Required API Key mapping
+// =========================================================================
+
+const MODEL_PROVIDERS = [
+  {
+    provider: "OpenAI",
+    prefixes: [
+      "gpt-",
+      "o1-",
+      "o3-",
+      "o4-",
+      "chatgpt-",
+      "dall-e",
+      "whisper",
+      "tts-",
+      "text-embedding",
+    ],
+    keys: ["OPENAI_API_KEY"],
+  },
+  {
+    provider: "Anthropic",
+    prefixes: ["claude-"],
+    keys: ["ANTHROPIC_API_KEY", "ANTROPIC_API_KEY"], // Intentional: common misspelling fallback
+  },
+  {
+    provider: "Google",
+    prefixes: ["gemini-", "models/gemini", "palm-"],
+    keys: ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
+  },
+  {
+    provider: "DeepSeek",
+    prefixes: ["deepseek-"],
+    keys: ["DEEPSEEK_API_KEY"],
+  },
+  {
+    provider: "Mistral",
+    prefixes: ["mistral-", "mixtral-", "codestral-", "pixtral-"],
+    keys: ["MISTRAL_API_KEY"],
+  },
+  {
+    provider: "Cohere",
+    prefixes: ["command-", "embed-", "rerank-"],
+    keys: ["COHERE_API_KEY"],
+  },
+  {
+    provider: "Perplexity",
+    prefixes: ["pplx-", "sonar-"],
+    keys: ["PERPLEXITY_API_KEY"],
+  },
+  {
+    provider: "Hume",
+    prefixes: ["hume-"],
+    keys: ["HUME_API_KEY"],
+  },
+];
+
+/**
+ * Identify the provider and required API key(s) for a model name.
+ *
+ * @param {string} modelName - e.g. "gpt-5-2025-08-07", "claude-3-opus"
+ * @returns {{ provider: string, keys: string[] } | null}
+ */
+function getModelProvider(modelName) {
+  if (!modelName) return null;
+  const m = modelName.toLowerCase();
+
+  for (const entry of MODEL_PROVIDERS) {
+    for (const prefix of entry.prefixes) {
+      if (m.startsWith(prefix)) {
+        return { provider: entry.provider, keys: entry.keys };
+      }
+    }
+  }
+  return null;
+}
+
+// =========================================================================
+// .env file parsing
+// =========================================================================
+
+/**
+ * Parse a .env file into a key-value object.
+ * Handles comments, quoted values, and blank lines.
+ *
+ * @param {string} envPath - Absolute path to .env file
+ * @returns {Object<string, string>}
+ */
+function parseEnvFile(envPath) {
+  const config = {};
+  try {
+    const content = fs.readFileSync(envPath, "utf8");
+    for (const raw of content.split("\n")) {
+      let line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      // Handle `export VAR=value` syntax
+      if (line.startsWith("export ")) {
+        line = line.substring(7).trim();
+      }
+      const eq = line.indexOf("=");
+      if (eq === -1) continue;
+      const key = line.substring(0, eq).trim();
+      let val = line.substring(eq + 1).trim();
+      // Strip surrounding quotes
+      const isQuoted =
+        (val.startsWith('"') && val.endsWith('"') && val.length >= 2) ||
+        (val.startsWith("'") && val.endsWith("'") && val.length >= 2);
+      if (isQuoted) {
+        val = val.slice(1, -1);
+      } else {
+        // Strip inline comments for unquoted values (e.g. "value # comment")
+        const commentIdx = val.indexOf(" #");
+        if (commentIdx > -1) val = val.substring(0, commentIdx).trim();
+      }
+      config[key] = val;
+    }
+  } catch {
+    // Silently return empty if file can't be read
+  }
+  return config;
+}
+
+// =========================================================================
+// Discover models & keys from parsed env
+// =========================================================================
+
+/**
+ * Scan env config for all *_MODEL and *_API_KEY variables.
+ *
+ * @param {Object} env - Parsed env object
+ * @returns {{ models: Object, keys: Object, validations: Array }}
+ */
+function discoverModelsAndKeys(env) {
+  const models = {};
+  const keys = {};
+
+  for (const [k, v] of Object.entries(env)) {
+    if (k.endsWith("_MODEL") || k === "DEFAULT_LLM_MODEL") {
+      models[k] = v;
+    }
+    if (k.endsWith("_API_KEY") || k.endsWith("_SECRET")) {
+      keys[k] = v ? "present" : "empty";
+    }
+  }
+
+  // Validate each model has a corresponding key
+  const validations = [];
+  for (const [varName, modelName] of Object.entries(models)) {
+    const info = getModelProvider(modelName);
+    if (!info) {
+      validations.push({
+        model: varName,
+        modelName,
+        status: "unknown_provider",
+        message: `Unknown provider for ${modelName}`,
+      });
+      continue;
+    }
+
+    const hasKey = info.keys.some((k) => env[k] && env[k].length > 5);
+    validations.push({
+      model: varName,
+      modelName,
+      provider: info.provider,
+      requiredKeys: info.keys,
+      hasKey,
+      status: hasKey ? "ok" : "MISSING_KEY",
+      message: hasKey
+        ? `${info.provider} key found for ${modelName}`
+        : `MISSING: ${info.keys.join(" or ")} required for ${modelName}`,
+    });
+  }
+
+  return { models, keys, validations };
+}
+
+// =========================================================================
+// .env creation from .env.example
+// =========================================================================
+
+/**
+ * If .env does not exist, create one from .env.example or generate a minimal template.
+ *
+ * @param {string} cwd - Project working directory
+ * @returns {{ created: boolean, source: string }}
+ */
+function ensureEnvFile(cwd) {
+  const envPath = path.join(cwd, ".env");
+  if (fs.existsSync(envPath)) {
+    return { created: false, source: "existing" };
+  }
+
+  // Try copying from .env.example
+  const examplePath = path.join(cwd, ".env.example");
+  if (fs.existsSync(examplePath)) {
+    try {
+      fs.copyFileSync(examplePath, envPath);
+      return { created: true, source: ".env.example" };
+    } catch {
+      // Fall through to template creation
+    }
+  }
+
+  // Generate minimal template
+  const template = [
+    "# Auto-generated .env template",
+    "# Fill in your API keys below",
+    "",
+    "# LLM Configuration",
+    "# OPENAI_API_KEY=sk-your-key-here",
+    "# OPENAI_PROD_MODEL=gpt-4o",
+    "# OPENAI_DEV_MODEL=gpt-4o-mini",
+    "# DEFAULT_LLM_MODEL=gpt-4o",
+    "",
+    "# ANTHROPIC_API_KEY=sk-ant-your-key-here",
+    "# GOOGLE_API_KEY=your-key-here",
+    "",
+    "# Database",
+    "# DATABASE_URL=postgresql://user:pass@localhost:5432/dbname",
+    "",
+    "# Authentication",
+    "# JWT_SECRET_KEY=change-this-to-a-random-string",
+    "",
+  ].join("\n");
+
+  try {
+    fs.writeFileSync(envPath, template);
+    return { created: true, source: "template" };
+  } catch {
+    return { created: false, source: "failed" };
+  }
+}
+
+// =========================================================================
+// Compact summary for hook output (survives context compression)
+// =========================================================================
+
+/**
+ * Build a terse summary string for injection into conversation context.
+ *
+ * @param {Object} env - Parsed env
+ * @param {{ models: Object, keys: Object, validations: Array }} discovery
+ * @returns {string}
+ */
+function buildCompactSummary(env, discovery) {
+  const parts = [];
+
+  // Models line
+  const modelParts = Object.entries(discovery.models)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+  if (modelParts) parts.push(`Models: ${modelParts}`);
+
+  // Key status line
+  const failures = discovery.validations.filter(
+    (v) => v.status === "MISSING_KEY",
+  );
+  if (failures.length > 0) {
+    parts.push(`MISSING KEYS: ${failures.map((f) => f.message).join("; ")}`);
+  } else if (discovery.validations.length > 0) {
+    parts.push("All model-key pairings validated");
+  }
+
+  return parts.join(" | ");
+}
+
+module.exports = {
+  MODEL_PROVIDERS,
+  getModelProvider,
+  parseEnvFile,
+  discoverModelsAndKeys,
+  ensureEnvFile,
+  buildCompactSummary,
+};

--- a/.claude/hooks/lib/learning-utils.js
+++ b/.claude/hooks/lib/learning-utils.js
@@ -1,0 +1,111 @@
+/**
+ * Shared utility: Per-project learning directory resolution and observation logging.
+ *
+ * Used by all hooks and learning scripts to ensure observations are stored
+ * per-project (in <project>/.claude/learning/) rather than globally.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+/**
+ * Resolve the learning directory for a given project.
+ *
+ * Priority:
+ *   1. KAILASH_LEARNING_DIR env var (for testing)
+ *   2. <cwd>/.claude/learning/ (per-project)
+ *   3. ~/.claude/kailash-learning/ (legacy fallback)
+ *
+ * @param {string} [cwd] - Project working directory
+ * @returns {string} Absolute path to the learning directory
+ */
+function resolveLearningDir(cwd) {
+  if (process.env.KAILASH_LEARNING_DIR) {
+    return process.env.KAILASH_LEARNING_DIR;
+  }
+  if (cwd) {
+    return path.join(cwd, ".claude", "learning");
+  }
+  return path.join(os.homedir(), ".claude", "kailash-learning");
+}
+
+/**
+ * Ensure the learning directory and its subdirectories exist.
+ *
+ * @param {string} [cwd] - Project working directory
+ * @returns {string} The resolved learning directory path
+ */
+function ensureLearningDir(cwd) {
+  const learningDir = resolveLearningDir(cwd);
+
+  const dirs = [learningDir, path.join(learningDir, "observations.archive")];
+
+  for (const dir of dirs) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch {}
+  }
+
+  return learningDir;
+}
+
+/**
+ * Append an observation to the per-project observations.jsonl file.
+ *
+ * @param {string} cwd - Project working directory
+ * @param {string} type - Observation type (e.g. "rule_violation", "user_correction", "workflow_pattern")
+ * @param {Object} data - Observation data payload
+ * @param {Object} [context] - Additional context (session_id, framework, etc.)
+ */
+function logObservation(cwd, type, data, context) {
+  try {
+    const learningDir = ensureLearningDir(cwd);
+    const observationsFile = path.join(learningDir, "observations.jsonl");
+
+    const observation = {
+      id: `obs_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      timestamp: new Date().toISOString(),
+      type,
+      data,
+      context: {
+        session_id: "unknown",
+        cwd: cwd || process.cwd(),
+        framework: "unknown",
+        ...context,
+      },
+    };
+
+    fs.appendFileSync(observationsFile, JSON.stringify(observation) + "\n");
+    return observation.id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count observations in the current observations.jsonl file.
+ *
+ * @param {string} learningDir - Learning directory path
+ * @returns {number} Number of observations
+ */
+function countObservations(learningDir) {
+  try {
+    const observationsFile = path.join(learningDir, "observations.jsonl");
+    if (!fs.existsSync(observationsFile)) return 0;
+    const content = fs.readFileSync(observationsFile, "utf8");
+    return content
+      .trim()
+      .split("\n")
+      .filter((l) => l).length;
+  } catch {
+    return 0;
+  }
+}
+
+module.exports = {
+  resolveLearningDir,
+  ensureLearningDir,
+  logObservation,
+  countObservations,
+};

--- a/.claude/hooks/lib/release-drift.js
+++ b/.claude/hooks/lib/release-drift.js
@@ -1,0 +1,135 @@
+/**
+ * Release drift detection for BUILD repos with Python packages.
+ *
+ * Scans pyproject.toml files in the repo root and packages/, finds the
+ * latest matching git tag per package, and reports packages with commits
+ * since that tag. Used by session-start and /wrapup to surface release
+ * backlogs before the next session or before ending the current session.
+ *
+ * Tag patterns tried (in order):
+ *   - 'v*' (root package only, e.g. v2.8.5)
+ *   - '<shortname>-v*' (e.g. dataflow-v2.0.7)
+ *   - '<full-name>-v*' (e.g. kailash-dataflow-v2.0.7)
+ * Shortname = package name with leading "kailash-" stripped.
+ *
+ * Silent when no packages OR no matching tags exist — does not flag
+ * downstream projects or non-package repos.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+function readPyproject(pyprojectPath) {
+  try {
+    const content = fs.readFileSync(pyprojectPath, "utf8");
+    const nameMatch = content.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    const versionMatch = content.match(/^\s*version\s*=\s*"([^"]+)"/m);
+    if (!nameMatch || !versionMatch) return null;
+    return { name: nameMatch[1], version: versionMatch[1] };
+  } catch {
+    return null;
+  }
+}
+
+function findPackages(cwd) {
+  const packages = [];
+
+  const rootPyproject = path.join(cwd, "pyproject.toml");
+  if (fs.existsSync(rootPyproject)) {
+    const info = readPyproject(rootPyproject);
+    if (info) packages.push({ ...info, path: "." });
+  }
+
+  const packagesDir = path.join(cwd, "packages");
+  if (fs.existsSync(packagesDir)) {
+    try {
+      for (const sub of fs.readdirSync(packagesDir)) {
+        const subPyproject = path.join(packagesDir, sub, "pyproject.toml");
+        if (fs.existsSync(subPyproject)) {
+          const info = readPyproject(subPyproject);
+          if (info) packages.push({ ...info, path: `packages/${sub}` });
+        }
+      }
+    } catch {}
+  }
+
+  return packages;
+}
+
+function git(cwd, args, timeoutMs = 2000) {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function latestTagMatching(cwd, patterns) {
+  for (const pattern of patterns) {
+    try {
+      const tag = git(cwd, [
+        "describe",
+        "--tags",
+        "--abbrev=0",
+        "--match",
+        pattern,
+        "HEAD",
+      ]);
+      if (tag) return tag;
+    } catch {}
+  }
+  return null;
+}
+
+function commitsSince(cwd, tag, pkgPath) {
+  try {
+    const args =
+      pkgPath === "."
+        ? ["rev-list", "--count", `${tag}..HEAD`]
+        : ["rev-list", "--count", `${tag}..HEAD`, "--", pkgPath];
+    const count = git(cwd, args);
+    return parseInt(count, 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * @param {string} cwd - project root
+ * @returns {Array<{name, current_version, last_tag, commits_since_tag, path}>}
+ *   Empty array when no packages, no tags, or nothing to release.
+ */
+function detectUnreleasedPackages(cwd) {
+  const packages = findPackages(cwd);
+  if (packages.length === 0) return [];
+
+  const unreleased = [];
+
+  for (const pkg of packages) {
+    const shortname = pkg.name.replace(/^kailash-/, "");
+    const patterns = [
+      pkg.path === "." ? "v*" : null,
+      `${shortname}-v*`,
+      `${pkg.name}-v*`,
+    ].filter(Boolean);
+
+    const latestTag = latestTagMatching(cwd, patterns);
+    if (!latestTag) continue; // repo doesn't tag this package — silent
+
+    const commits = commitsSince(cwd, latestTag, pkg.path);
+    if (commits > 0) {
+      unreleased.push({
+        name: pkg.name,
+        current_version: pkg.version,
+        last_tag: latestTag,
+        commits_since_tag: commits,
+        path: pkg.path,
+      });
+    }
+  }
+
+  return unreleased;
+}
+
+module.exports = { detectUnreleasedPackages, findPackages };

--- a/.claude/hooks/lib/runtime.js
+++ b/.claude/hooks/lib/runtime.js
@@ -1,0 +1,75 @@
+/**
+ * Shared hook runtime — COC_RUNTIME closed-enum validation + parseHook contract.
+ *
+ * Used by:
+ *   - .claude/hooks/*.js (CommonJS consumers, via require)
+ *   - .claude/codex-mcp-guard/server.js (via require — MCP guard companion)
+ *
+ * The COC_RUNTIME env var is a closed enum: {cc, codex, gemini}. Silent
+ * passthrough of an unknown value is BLOCKED (zero-tolerance Rule 3 — no
+ * silent fallbacks). See v3 §4.3 PoC C-2.
+ *
+ * Origin: v3 §4.3 + v5 session 2026-04-22 (analyst B-19 Defect 1 — module
+ * was referenced by MCP guard but never authored).
+ */
+
+const VALID_RUNTIMES = new Set(["cc", "codex", "gemini"]);
+
+/**
+ * Normalize a CLI-specific hook event name to a canonical form.
+ * CC uses PascalCase (`PreToolUse`); Codex / Gemini may use snake_case.
+ */
+function normalizeEvent(hookEventName, runtime) {
+  if (!hookEventName) return null;
+  if (runtime === "cc") return hookEventName;
+  // codex / gemini snake_case → PascalCase
+  return hookEventName
+    .split("_")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+}
+
+/**
+ * Parse a raw hook-invocation JSON payload into the canonical shape every
+ * hook consumes. Validates COC_RUNTIME at parse time; throws on unknown or
+ * missing runtime rather than silently defaulting.
+ *
+ * @param {string} raw - JSON-encoded hook payload (from stdin or MCP call)
+ * @returns {object} - { runtime, event, toolName, toolInput, prompt, sessionId, cwd, projectDir }
+ * @throws {Error} - if COC_RUNTIME is unset or not in VALID_RUNTIMES
+ */
+function parseHook(raw) {
+  const runtime = process.env.COC_RUNTIME;
+  if (!runtime) {
+    throw new Error(
+      "COC_RUNTIME env not set; emitter-generated wrapper required " +
+        "(set COC_RUNTIME=cc|codex|gemini before invoking hook)",
+    );
+  }
+  if (!VALID_RUNTIMES.has(runtime)) {
+    throw new Error(
+      `COC_RUNTIME='${runtime}' invalid; must be cc, codex, or gemini`,
+    );
+  }
+
+  const data = JSON.parse(raw);
+  return {
+    runtime,
+    event: normalizeEvent(data.hook_event_name, runtime),
+    toolName: data.tool_name ?? (data.tool && data.tool.name),
+    toolInput: data.tool_input ?? (data.tool && data.tool.input),
+    prompt: data.prompt ?? data.user_prompt,
+    sessionId: data.session_id,
+    cwd: data.cwd,
+    projectDir:
+      process.env.CLAUDE_PROJECT_DIR ||
+      process.env.GEMINI_PROJECT_DIR ||
+      process.env.CODEX_HOME,
+  };
+}
+
+module.exports = {
+  VALID_RUNTIMES,
+  parseHook,
+  normalizeEvent,
+};

--- a/.claude/hooks/lib/template-resolver.js
+++ b/.claude/hooks/lib/template-resolver.js
@@ -1,0 +1,243 @@
+/**
+ * Resolve a COC USE template to a local path.
+ *
+ * Resolution order (changed v2.9.1 to fix the stale-local-clone footgun):
+ *
+ *   1. KAILASH_COC_TEMPLATE_PATH env var — explicit developer escape hatch.
+ *      Use this when iterating on un-pushed local template changes.
+ *      MUST point at a directory containing `.claude/`.
+ *   2. Cache at `~/.cache/kailash-coc/<template>/` — auto-updated via
+ *      `git fetch --depth 1 origin main && git reset --hard origin/main`.
+ *      This is the default fast path on every sync after first.
+ *   3. Shallow clone from GitHub to cache if no cache exists.
+ *   4. Local sibling directory — OFFLINE FALLBACK ONLY. Used only when
+ *      every network operation in steps 2-3 fails (no network, GitHub
+ *      unreachable, repo private without auth).
+ *
+ * Why this order:
+ *   Pre-v2.9.1 the local sibling was step 1 — a one-time clone of the
+ *   template, kept locally for any reason, would silently shadow the
+ *   auto-updating cache forever, forcing users to `git pull` two repos
+ *   before every downstream sync. The sibling path had no freshness
+ *   guarantee. Now origin/main is always authoritative; the sibling
+ *   becomes a true offline fallback that never wins against fresh remote.
+ *
+ *   When a sibling is detected but bypassed (default online path), we
+ *   emit a one-line stderr notice telling the user how to opt back in
+ *   via KAILASH_COC_TEMPLATE_PATH if that's actually what they wanted.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const CACHE_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE,
+  ".cache",
+  "kailash-coc",
+);
+
+const KNOWN_TEMPLATES = {
+  "kailash-coc-claude-py": "terrene-foundation/kailash-coc-claude-py",
+  "kailash-coc-claude-rs": "terrene-foundation/kailash-coc-claude-rs",
+  "kailash-coc-claude-rb": "terrene-foundation/kailash-coc-claude-rb",
+  "kailash-coc-claude-prism": "terrene-foundation/kailash-coc-claude-prism",
+  "kailash-coc-py": "terrene-foundation/kailash-coc-py",
+  "kailash-coc-rs": "terrene-foundation/kailash-coc-rs",
+};
+
+/**
+ * Resolve the USE template for a downstream project.
+ * @param {string} cwd - project root directory
+ * @returns {{ path: string, source: string, fresh: boolean } | { error: string }}
+ */
+function resolveTemplate(cwd) {
+  const versionPath = path.join(cwd, ".claude", "VERSION");
+  if (!fs.existsSync(versionPath)) {
+    return {
+      error:
+        "No .claude/VERSION file found. Run a session first to auto-create it.",
+    };
+  }
+
+  let version;
+  try {
+    version = JSON.parse(fs.readFileSync(versionPath, "utf8"));
+  } catch (e) {
+    return { error: `Failed to parse .claude/VERSION: ${e.message}` };
+  }
+
+  const upstream = version.upstream || {};
+  const templateName = upstream.template;
+  const templateRepo = upstream.template_repo;
+
+  if (!templateName || templateName === "unknown") {
+    return {
+      error:
+        'No upstream.template in .claude/VERSION (or set to "unknown"). ' +
+        "Set it to the template name, e.g.: " +
+        '"template": "kailash-coc-claude-py"',
+    };
+  }
+
+  // 1. Explicit developer escape hatch via env var.
+  const envOverride = process.env.KAILASH_COC_TEMPLATE_PATH;
+  if (envOverride) {
+    if (fs.existsSync(path.join(envOverride, ".claude"))) {
+      return { path: envOverride, source: "env-override", fresh: true };
+    }
+    console.error(
+      `[TEMPLATE] KAILASH_COC_TEMPLATE_PATH=${envOverride} does not contain .claude/ — ignoring.`,
+    );
+  }
+
+  // Detect (but do NOT use) any local sibling so we can emit a one-line
+  // notice if the user has a stale clone they may not realize is being
+  // bypassed. This is a UX nudge, not a fallback.
+  const sibling = findLocalSibling(cwd, templateName);
+  if (sibling && !envOverride) {
+    console.error(
+      `[TEMPLATE] Found local clone at ${sibling} but using GitHub-backed cache for freshness. ` +
+        `To use the local clone instead, set KAILASH_COC_TEMPLATE_PATH=${sibling}.`,
+    );
+  }
+
+  // 2. Cache hit — refresh from origin/main and use.
+  const cachePath = path.join(CACHE_DIR, templateName);
+  if (fs.existsSync(path.join(cachePath, ".claude"))) {
+    const updated = updateCachedClone(cachePath);
+    if (updated) {
+      return { path: cachePath, source: "cache", fresh: true };
+    }
+    // Cache exists but fetch failed (offline). Fall through to clone retry,
+    // and ultimately to the offline-sibling fallback if the network really is down.
+    console.error(
+      `[TEMPLATE] Cache fetch failed; trying fresh clone, then offline fallback.`,
+    );
+  }
+
+  // 3. Shallow clone to cache.
+  const repoSlug = templateRepo || KNOWN_TEMPLATES[templateName];
+  if (repoSlug) {
+    const cloned = cloneToCache(repoSlug, cachePath);
+    if (cloned) {
+      return { path: cachePath, source: "cloned", fresh: true };
+    }
+  }
+
+  // 4. Last-resort offline fallback: use the local sibling if one exists.
+  // This is reached ONLY if every network path above failed.
+  if (sibling) {
+    console.error(
+      `[TEMPLATE] Network unreachable. Falling back to local sibling at ${sibling} ` +
+        `— freshness NOT guaranteed. Run \`git -C ${sibling} pull\` if you suspect it's stale.`,
+    );
+    return { path: sibling, source: "sibling-offline-fallback", fresh: false };
+  }
+
+  return {
+    error:
+      `Failed to resolve template "${templateName}". Tried env override (KAILASH_COC_TEMPLATE_PATH), ` +
+      `GitHub-backed cache at ${cachePath}, ` +
+      (repoSlug
+        ? `shallow clone from github.com/${repoSlug}, `
+        : `(no template_repo in VERSION and no known slug for "${templateName}"), `) +
+      `and offline sibling lookup. Check network connectivity, repo access, and that ` +
+      `upstream.template_repo is set in .claude/VERSION.`,
+  };
+}
+
+/**
+ * Search for the template as a local directory.
+ * Used ONLY for the detection notice (step 1 nudge) and the offline fallback
+ * (step 4). Never used as the default resolution path online.
+ */
+function findLocalSibling(cwd, templateName) {
+  const candidates = [];
+
+  candidates.push(path.join(path.dirname(cwd), templateName));
+
+  const parent = path.dirname(cwd);
+  candidates.push(path.join(parent, "loom", templateName));
+
+  const home = process.env.HOME || process.env.USERPROFILE;
+  candidates.push(path.join(home, "repos", "loom", templateName));
+  candidates.push(path.join(home, "repos", templateName));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, ".claude")) && candidate !== cwd) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Fetch latest from origin/main in an existing cached clone.
+ */
+function updateCachedClone(cachePath) {
+  try {
+    execFileSync(
+      "git",
+      ["-C", cachePath, "fetch", "--depth", "1", "origin", "main"],
+      { timeout: 15000, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    execFileSync("git", ["-C", cachePath, "reset", "--hard", "origin/main"], {
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch (e) {
+    console.error(`[TEMPLATE] Cache update failed: ${e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Shallow clone a template repo to the cache directory.
+ */
+function cloneToCache(repoSlug, cachePath) {
+  const httpsUrl = `https://github.com/${repoSlug}.git`;
+  const sshUrl = `git@github.com:${repoSlug}.git`;
+  const cloneArgs = [
+    "clone",
+    "--depth",
+    "1",
+    "--single-branch",
+    "--branch",
+    "main",
+  ];
+
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+
+  try {
+    execFileSync("git", [...cloneArgs, httpsUrl, cachePath], {
+      timeout: 30000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch (httpsErr) {
+    try {
+      execFileSync("git", [...cloneArgs, sshUrl, cachePath], {
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return true;
+    } catch (sshErr) {
+      console.error(
+        `[TEMPLATE] Clone failed — HTTPS: ${httpsErr.message}, SSH: ${sshErr.message}`,
+      );
+      return false;
+    }
+  }
+}
+
+module.exports = {
+  resolveTemplate,
+  findLocalSibling,
+  updateCachedClone,
+  cloneToCache,
+  KNOWN_TEMPLATES,
+  CACHE_DIR,
+};

--- a/.claude/hooks/lib/version-utils.js
+++ b/.claude/hooks/lib/version-utils.js
@@ -1,0 +1,406 @@
+/**
+ * Version tracking utilities for CO/COC artifact ecosystem.
+ *
+ * Each repo has a .claude/VERSION file (JSON) with type-specific fields:
+ *   - coc-source:        version, no upstream (loom/)
+ *   - coc-use-template:  upstream.build_version (coc-claude-py, coc-claude-rs)
+ *   - coc-build:         upstream.build_version (kailash-py, kailash-rs)
+ *   - coc-project:       upstream.template_version (downstream projects)
+ *
+ * The session-start hook calls checkVersion() to:
+ *   1. Read local VERSION (auto-create if missing with detected type)
+ *   2. Source repos: report source status
+ *   3. Template/BUILD repos: display tracked build version info (no fetch)
+ *   4. Downstream projects: display tracked template version info (no fetch)
+ *   5. Legacy repos with version_url: fetch remote and compare
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+/**
+ * Read the local .claude/VERSION file.
+ * @param {string} cwd - project root
+ * @returns {object|null} parsed VERSION or null if missing
+ */
+function readLocalVersion(cwd) {
+  const versionPath = path.join(cwd, ".claude", "VERSION");
+  try {
+    const content = fs.readFileSync(versionPath, "utf8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch upstream VERSION from GitHub (via curl, no dependencies).
+ * Times out after 3 seconds to avoid blocking session start.
+ * @param {string} url - raw GitHub URL to VERSION file
+ * @returns {object|null} parsed remote VERSION or null on failure
+ */
+function fetchUpstreamVersion(url) {
+  if (!url) return null;
+  try {
+    const result = execFileSync("curl", ["-sf", "--max-time", "3", url], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare local tracked upstream version vs actual remote version.
+ * @param {object} local - local VERSION object
+ * @param {object} remote - remote VERSION object (fetched from GitHub)
+ * @returns {object} { status, message, localVersion, remoteVersion, changelog }
+ *   status: "current" | "update-available" | "unknown"
+ */
+function compareVersions(local, remote) {
+  if (!local || !local.upstream) {
+    return { status: "source", message: "This is a source repo (no upstream)" };
+  }
+
+  if (!remote) {
+    return {
+      status: "unknown",
+      message: `Could not reach upstream (${local.upstream.name}). Offline or repo not public.`,
+      localVersion: local.version,
+      trackedUpstream: local.upstream.version,
+    };
+  }
+
+  const tracked = local.upstream.version;
+  const actual = remote.version;
+
+  if (tracked === actual) {
+    return {
+      status: "current",
+      message: `Artifacts current with ${local.upstream.name} v${actual}`,
+      localVersion: local.version,
+      trackedUpstream: tracked,
+    };
+  }
+
+  // Find changelog entries newer than what we track
+  const newEntries = (remote.changelog || []).filter((entry) => {
+    return entry.version !== tracked && isNewer(entry.version, tracked);
+  });
+
+  const changeSummary = newEntries
+    .map((e) => `  v${e.version} (${e.date}): ${e.summary}`)
+    .join("\n");
+
+  return {
+    status: "update-available",
+    message: `Update available: ${local.upstream.name} v${tracked} → v${actual}`,
+    localVersion: local.version,
+    trackedUpstream: tracked,
+    remoteVersion: actual,
+    changelog: changeSummary || `  v${actual}: (no changelog details)`,
+  };
+}
+
+/**
+ * Simple semver comparison: is a newer than b?
+ * Returns false for missing/malformed inputs (NaN guard).
+ */
+function isNewer(a, b) {
+  if (!a || !b || typeof a !== "string" || typeof b !== "string") return false;
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const ai = pa[i];
+    const bi = pb[i];
+    if (Number.isNaN(ai) || Number.isNaN(bi)) return false;
+    if ((ai || 0) > (bi || 0)) return true;
+    if ((ai || 0) < (bi || 0)) return false;
+  }
+  return false;
+}
+
+/**
+ * Detect repo type for bootstrap based on directory structure.
+ * @param {string} cwd - project root
+ * @returns {string} "coc-build" | "coc-project"
+ */
+function detectRepoType(cwd) {
+  const hasPyproject = fs.existsSync(path.join(cwd, "pyproject.toml"));
+  const hasCargo = fs.existsSync(path.join(cwd, "Cargo.toml"));
+  const hasPackages = fs.existsSync(path.join(cwd, "packages"));
+  const hasSrc = fs.existsSync(path.join(cwd, "src"));
+
+  if ((hasPackages || hasSrc) && (hasPyproject || hasCargo)) {
+    return "coc-build";
+  }
+  return "coc-project";
+}
+
+/**
+ * Main entry point for session-start hook.
+ * @param {string} cwd - project root
+ * @returns {object} { status, messages[] } for stderr output
+ */
+function checkVersion(cwd) {
+  let local = readLocalVersion(cwd);
+  if (!local) {
+    // Auto-create VERSION if .claude/ exists but VERSION doesn't (per 08-versioning.md)
+    const claudeDir = path.join(cwd, ".claude");
+    if (fs.existsSync(claudeDir)) {
+      const detectedType = detectRepoType(cwd);
+      const bootstrapped = {
+        version: "0.0.0",
+        type: detectedType,
+        updated: new Date().toISOString().split("T")[0],
+        description:
+          "Auto-created — run /sync to pull latest template artifacts",
+        upstream:
+          detectedType === "coc-build"
+            ? {
+                source: "unknown",
+                build_version: "0.0.0",
+                synced_at: null,
+              }
+            : {
+                template: "unknown",
+                template_version: "0.0.0",
+                synced_at: null,
+              },
+      };
+      const versionPath = path.join(claudeDir, "VERSION");
+      try {
+        fs.writeFileSync(
+          versionPath,
+          JSON.stringify(bootstrapped, null, 2) + "\n",
+        );
+        local = bootstrapped;
+        return {
+          status: "bootstrapped",
+          messages: [
+            `[VERSION] Created initial VERSION file (v0.0.0, type: ${detectedType})`,
+            "[VERSION] Run /sync to pull latest template artifacts",
+          ],
+        };
+      } catch {
+        return { status: "no-version", messages: [] };
+      }
+    }
+    return { status: "no-version", messages: [] };
+  }
+
+  const messages = [
+    `[VERSION] ${local.description || local.type} v${local.version}`,
+  ];
+
+  const repoType = local.type || "coc-project";
+  const upstream = local.upstream || {};
+
+  // --- Source repos: fetch remote, compare ---
+  if (repoType === "coc-source" || !local.upstream) {
+    if (!local.upstream) {
+      messages.push("[VERSION] Source repo — no upstream to check");
+    } else {
+      messages.push("[VERSION] Source repo (coc-source)");
+    }
+    return { status: "source", messages };
+  }
+
+  // --- USE template / BUILD repos: display tracked version info ---
+  // But first: detect if this is a template-derived repo that needs correction.
+  // When a user creates a repo via "Use this template" on GitHub, they inherit
+  // the template's VERSION with type "coc-use-template" — but their repo is
+  // actually a downstream project (coc-project).
+  if (repoType === "coc-use-template" || repoType === "coc-build") {
+    if (repoType === "coc-use-template" && !isActualTemplateRepo(cwd)) {
+      const corrected = correctTemplateDerivedVersion(cwd, local);
+      if (corrected) {
+        messages.push(
+          `[VERSION] ⚠ Auto-corrected: this repo was created from a USE template but is a downstream project`,
+        );
+        messages.push(
+          `[VERSION] Type changed to coc-project, template set to ${corrected.upstream.template}. Run /sync to update.`,
+        );
+        return { status: "corrected", messages };
+      }
+    }
+    const buildVer = upstream.build_version || "unknown";
+    const syncedAt = upstream.synced_at ? ` synced ${upstream.synced_at}` : "";
+    messages.push(
+      `[VERSION] COC artifacts from loom v${local.version}, build v${buildVer}${syncedAt}`,
+    );
+    return { status: "tracked", messages };
+  }
+
+  // --- Downstream projects: display template tracking info ---
+  if (repoType === "coc-project") {
+    const tmpl = upstream.template || "unknown";
+    const tmplVer = upstream.template_version || "unknown";
+    const syncedAt = upstream.synced_at ? `, synced ${upstream.synced_at}` : "";
+    messages.push(
+      `[VERSION] COC from template ${tmpl}, v${tmplVer}${syncedAt}`,
+    );
+    if (tmpl === "unknown") {
+      messages.push(
+        `[VERSION] ⚠ Template unknown — set upstream.template in .claude/VERSION (e.g., "kailash-coc-claude-py") then run /sync`,
+      );
+    }
+    return { status: "tracked", messages };
+  }
+
+  // --- Fallback: legacy repos with upstream.version_url (source-style fetch) ---
+  const remote = fetchUpstreamVersion(upstream.version_url);
+  const result = compareVersions(local, remote);
+
+  if (result.status === "current") {
+    messages.push(`[VERSION] ${result.message}`);
+  } else if (result.status === "update-available") {
+    messages.push(`[VERSION] ⚠ ${result.message}`);
+    messages.push("[VERSION] Changes:");
+    messages.push(result.changelog);
+    messages.push("[VERSION] Run /sync to update artifacts");
+  } else {
+    messages.push(`[VERSION] ${result.message}`);
+  }
+
+  return { status: result.status, messages };
+}
+
+/**
+ * Known USE template repos — GitHub slugs that ARE actual templates.
+ * If a repo's git remote matches one of these, it's the real template,
+ * not a downstream project created from it.
+ */
+const KNOWN_TEMPLATE_REPOS = {
+  "terrene-foundation/kailash-coc-claude-py": "kailash-coc-claude-py",
+  "terrene-foundation/kailash-coc-claude-rs": "kailash-coc-claude-rs",
+  "terrene-foundation/kailash-coc-claude-rb": "kailash-coc-claude-rb",
+  "terrene-foundation/kailash-coc-claude-prism": "kailash-coc-claude-prism",
+};
+
+/**
+ * Check if this repo is actually a USE template repo (not just derived from one).
+ * Checks directory name (monorepo safeguard) and git remote origin.
+ */
+function isActualTemplateRepo(cwd) {
+  const dirName = path.basename(cwd);
+  if (Object.values(KNOWN_TEMPLATE_REPOS).includes(dirName)) {
+    return true;
+  }
+  try {
+    let remote = execFileSync(
+      "git",
+      ["-C", cwd, "remote", "get-url", "origin"],
+      { encoding: "utf8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+    // Normalize SSH URLs: git@github.com:owner/repo.git → owner/repo
+    if (remote.startsWith("git@")) {
+      remote = (remote.split(":")[1] || "").replace(/\.git$/, "");
+    }
+    for (const slug of Object.keys(KNOWN_TEMPLATE_REPOS)) {
+      if (remote.includes(slug)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Auto-correct a VERSION file that was inherited from a USE template.
+ * Converts coc-use-template → coc-project with proper upstream fields.
+ * Returns the corrected version object, or null on failure.
+ */
+function correctTemplateDerivedVersion(cwd, original) {
+  const templateName = guessTemplateName(cwd, original);
+  const templateSlug = templateName
+    ? Object.entries(KNOWN_TEMPLATE_REPOS).find(
+        ([, name]) => name === templateName,
+      )?.[0] || null
+    : null;
+
+  const corrected = {
+    version: original.version || "0.0.0",
+    type: "coc-project",
+    description: original.description
+      ? original.description.replace(/USE template/i, "downstream project")
+      : "Downstream project (auto-corrected from template)",
+    updated: new Date().toISOString().split("T")[0],
+    upstream: {
+      template: templateName || "unknown",
+      template_repo: templateSlug || null,
+      template_version: original.version || "0.0.0",
+      synced_at: (original.upstream || {}).synced_at || null,
+      sdk_packages: (original.upstream || {}).sdk_packages || {},
+    },
+  };
+
+  const versionPath = path.join(cwd, ".claude", "VERSION");
+  try {
+    fs.writeFileSync(versionPath, JSON.stringify(corrected, null, 2) + "\n");
+    return corrected;
+  } catch (e) {
+    console.error(`[VERSION] Failed to write corrected VERSION: ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Guess which template this repo was derived from.
+ * Uses the variant field or upstream.name from the original VERSION.
+ */
+function guessTemplateName(cwd, original) {
+  const variant = original.variant;
+  if (variant) {
+    return `kailash-coc-claude-${variant}`;
+  }
+  // Check git remote for template repo name hints
+  try {
+    const remote = execFileSync(
+      "git",
+      ["-C", cwd, "remote", "get-url", "origin"],
+      { encoding: "utf8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+    // Check if the repo was CREATED from a template — git initial commit
+    // may reference the template. Also check first commit message.
+  } catch {}
+  // Check description — but "Rust-backed" bindings means rs template,
+  // even though "Python/Ruby" appears first in the description.
+  const desc = (original.description || "").toLowerCase();
+  if (
+    desc.includes("rust-backed") ||
+    desc.includes("kailash-rs") ||
+    desc.includes("rs bindings")
+  ) {
+    return "kailash-coc-claude-rs";
+  }
+  if (desc.includes("prism") || desc.includes("composable")) {
+    return "kailash-coc-claude-prism";
+  }
+  if (desc.includes("ruby") && !desc.includes("rust")) {
+    return "kailash-coc-claude-rb";
+  }
+  if (desc.includes("python") || desc.includes("-py")) {
+    return "kailash-coc-claude-py";
+  }
+  // Check upstream.name or upstream.source
+  const upstreamName = (original.upstream || {}).name || "";
+  if (upstreamName) {
+    return "kailash-coc-claude-py";
+  }
+  return null;
+}
+
+module.exports = {
+  readLocalVersion,
+  fetchUpstreamVersion,
+  compareVersions,
+  checkVersion,
+  detectRepoType,
+  isActualTemplateRepo,
+  correctTemplateDerivedVersion,
+};

--- a/.claude/hooks/lib/workspace-utils.js
+++ b/.claude/hooks/lib/workspace-utils.js
@@ -1,0 +1,258 @@
+/**
+ * Shared utility: Workspace detection and phase derivation.
+ *
+ * Used by session-start.js, user-prompt-rules-reminder.js, and phase commands.
+ * Framework-agnostic — works with any Kailash project.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Detect the active workspace under workspaces/.
+ * Returns the most recently modified project directory, or null if none.
+ *
+ * @param {string} cwd - Project root directory
+ * @returns {{ name: string, path: string } | null}
+ */
+function detectActiveWorkspace(cwd) {
+  const wsDir = path.join(cwd, "workspaces");
+  try {
+    const entries = fs.readdirSync(wsDir, { withFileTypes: true });
+    const projects = entries
+      .filter((e) => e.isDirectory() && e.name !== "instructions")
+      .map((e) => {
+        const fullPath = path.join(wsDir, e.name);
+        try {
+          const stat = fs.statSync(fullPath);
+          return { name: e.name, path: fullPath, mtime: stat.mtime.getTime() };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean)
+      .sort((a, b) => b.mtime - a.mtime);
+
+    return projects.length > 0
+      ? { name: projects[0].name, path: projects[0].path }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the current phase from workspace filesystem state.
+ *
+ * Heuristics (evaluated in reverse order — latest phase takes priority):
+ * - Has .claude/agents/project/ or .claude/skills/project/ files -> phase 05
+ * - Has 04-validate/ with files -> phase 04
+ * - Has todos/completed/ with files OR src/ or apps/ with files -> phase 03
+ * - Has todos/active/ with files -> phase 02
+ * - Has 01-analysis/ or 02-plans/ or 03-user-flows/ -> phase 01
+ * - Empty workspace -> not-started
+ *
+ * @param {string} workspacePath - Absolute path to workspace directory
+ * @param {string} cwd - Project root (for checking .claude/agents/project/)
+ * @returns {string} Phase identifier
+ */
+function derivePhase(workspacePath, cwd) {
+  // Check for phase 05 artifacts
+  if (cwd) {
+    const agentProjectDir = path.join(cwd, ".claude", "agents", "project");
+    const skillProjectDir = path.join(cwd, ".claude", "skills", "project");
+    if (dirHasFiles(agentProjectDir) || dirHasFiles(skillProjectDir)) {
+      return "05-codify";
+    }
+  }
+
+  // Check for phase 04 artifacts
+  if (dirHasFiles(path.join(workspacePath, "04-validate"))) {
+    return "04-validate";
+  }
+
+  // Check for implementation activity (phase 03)
+  const completedCount = countFiles(
+    path.join(workspacePath, "todos", "completed"),
+  );
+  if (
+    completedCount > 0 ||
+    dirHasFiles(path.join(workspacePath, "src")) ||
+    dirHasFiles(path.join(workspacePath, "apps"))
+  ) {
+    return "03-implement";
+  }
+
+  // Check for todos (phase 02)
+  const activeCount = countFiles(path.join(workspacePath, "todos", "active"));
+  if (activeCount > 0) {
+    return "02-todos";
+  }
+
+  // Check for analysis artifacts (phase 01)
+  if (
+    dirHasFiles(path.join(workspacePath, "01-analysis")) ||
+    dirHasFiles(path.join(workspacePath, "02-plans")) ||
+    dirHasFiles(path.join(workspacePath, "03-user-flows"))
+  ) {
+    return "01-analyze";
+  }
+
+  return "not-started";
+}
+
+/**
+ * Get todo progress counts.
+ *
+ * @param {string} workspacePath
+ * @returns {{ active: number, completed: number }}
+ */
+function getTodoProgress(workspacePath) {
+  return {
+    active: countFiles(path.join(workspacePath, "todos", "active")),
+    completed: countFiles(path.join(workspacePath, "todos", "completed")),
+  };
+}
+
+/**
+ * Read .session-notes content if present.
+ *
+ * @param {string} workspacePath
+ * @returns {{ content: string, stale: boolean, age: string } | null}
+ */
+function getSessionNotes(workspacePath) {
+  const notesPath = path.join(workspacePath, ".session-notes");
+  return readSessionNotesFile(notesPath);
+}
+
+/**
+ * Find all .session-notes across repo root and workspaces, sorted newest first.
+ *
+ * Searches:
+ *   1. cwd/.session-notes (repo root)
+ *   2. cwd/workspaces/<dir>/.session-notes (all workspace dirs)
+ *
+ * @param {string} cwd - Project root directory
+ * @returns {Array<{ path: string, relativePath: string, workspace: string|null, content: string, stale: boolean, age: string, mtime: number }>}
+ */
+function findAllSessionNotes(cwd) {
+  const results = [];
+
+  // Check repo root
+  const rootNotes = path.join(cwd, ".session-notes");
+  const rootResult = readSessionNotesFile(rootNotes);
+  if (rootResult) {
+    results.push({
+      ...rootResult,
+      path: rootNotes,
+      relativePath: ".session-notes",
+      workspace: null,
+    });
+  }
+
+  // Check all workspace dirs
+  const wsDir = path.join(cwd, "workspaces");
+  try {
+    const entries = fs.readdirSync(wsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === "instructions") continue;
+      const notesPath = path.join(wsDir, entry.name, ".session-notes");
+      const result = readSessionNotesFile(notesPath);
+      if (result) {
+        results.push({
+          ...result,
+          path: notesPath,
+          relativePath: `workspaces/${entry.name}/.session-notes`,
+          workspace: entry.name,
+        });
+      }
+    }
+  } catch {}
+
+  // Sort newest first
+  results.sort((a, b) => b.mtime - a.mtime);
+  return results;
+}
+
+/**
+ * Read a single .session-notes file and compute age metadata.
+ *
+ * @param {string} notesPath - Absolute path to .session-notes
+ * @returns {{ content: string, stale: boolean, age: string, mtime: number } | null}
+ */
+function readSessionNotesFile(notesPath) {
+  try {
+    const content = fs.readFileSync(notesPath, "utf8");
+    const stat = fs.statSync(notesPath);
+    const mtime = stat.mtime.getTime();
+    const ageMs = Date.now() - mtime;
+    const ageHours = Math.round(ageMs / (1000 * 60 * 60));
+    const stale = ageMs > 24 * 60 * 60 * 1000;
+
+    let age;
+    if (ageHours < 1) age = "< 1h ago";
+    else if (ageHours < 24) age = `${ageHours}h ago`;
+    else age = `${Math.round(ageHours / 24)}d ago`;
+
+    return { content: content.trim(), stale, age, mtime };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a compact 1-line workspace summary for per-turn injection.
+ *
+ * @param {string} cwd
+ * @returns {string | null}
+ */
+function buildWorkspaceSummary(cwd) {
+  const ws = detectActiveWorkspace(cwd);
+  if (!ws) return null;
+
+  const phase = derivePhase(ws.path, cwd);
+  const todos = getTodoProgress(ws.path);
+
+  const parts = [ws.name, `Phase: ${phase}`];
+  if (todos.active > 0 || todos.completed > 0) {
+    parts.push(`Todos: ${todos.active} active / ${todos.completed} done`);
+  }
+
+  // Surface journal candidates waiting for review (written by SessionEnd hook)
+  const pending = countFiles(path.join(ws.path, "journal", ".pending"));
+  if (pending > 0) {
+    parts.push(`Journal candidates pending: ${pending}`);
+  }
+
+  return parts.join(" | ");
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function dirHasFiles(dirPath) {
+  try {
+    const entries = fs.readdirSync(dirPath);
+    return entries.some((e) => !e.startsWith("."));
+  } catch {
+    return false;
+  }
+}
+
+function countFiles(dirPath) {
+  try {
+    return fs.readdirSync(dirPath).filter((e) => !e.startsWith(".")).length;
+  } catch {
+    return 0;
+  }
+}
+
+module.exports = {
+  detectActiveWorkspace,
+  derivePhase,
+  getTodoProgress,
+  getSessionNotes,
+  findAllSessionNotes,
+  buildWorkspaceSummary,
+  dirHasFiles,
+  countFiles,
+};

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ downloads/
 eggs/
 .eggs/
 lib/
-!scripts/hooks/lib/
+!.claude/hooks/lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
## Summary

- `.gitignore` previously had `lib/` rule + whitelist pinned to the legacy `scripts/hooks/lib/` location, masking the v2.9.x canonical `.claude/hooks/lib/` payload (7 sibling modules) from every commit since v2.9.0.
- Downstream consumers that cloned post-v2.9.0 hit `Cannot find module './lib/<sibling>'` on CC startup; csq preflight reported `hook require fails: ... sibling modules missing`.
- Fix: replaced `!scripts/hooks/lib/` whitelist with `!.claude/hooks/lib/` (legacy path is obsoleted via `.coc-obsoleted` from v2.9.1). First commit of the 7 sibling modules to git history.
- VERSION bump 2.9.15 → 2.9.16 so downstream `/sync` re-activates.

## Test plan

- [x] `git check-ignore -v .claude/hooks/lib/env-utils.js` — exits 1 (no longer ignored)
- [x] `git ls-files .claude/hooks/lib/` — lists all 7 sibling modules
- [x] `python3 -c 'import json; json.load(open(".claude/VERSION"))'` — VERSION parses
- [ ] Downstream `/sync` from this template re-activates (will verify after admin-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)