### PR TITLE
fix(pyproject): pin to kailash-enterprise (binding wheel name) — kailash>=3.23.0 broke uv sync

### DIFF
--- a/.claude/skills/06-python-bindings/python-v2-quickstart.md
+++ b/.claude/skills/06-python-bindings/python-v2-quickstart.md
@@ -11,8 +11,9 @@ Fastest path to running workflows with the Rust-backed `kailash` package.
 ## Installation
 
 ```bash
-# From PyPI (production)
-pip install kailash
+# From PyPI (production) — distribution name is `kailash-enterprise`,
+# import name is `import kailash`.
+pip install kailash-enterprise
 
 # Development mode (when working inside the kailash workspace)
 cd bindings/kailash-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ classifiers = [
 ]
 dependencies = [
     # Kailash (Rust-accelerated Python binding — free, no registration, no gating).
-    # Published on PyPI, source hosted on the Terrene Foundation GitHub org.
-    # The binding links against a Rust runtime whose source is trade secret,
-    # but install + use is free for every user.
+    # The PyPI distribution name is `kailash-enterprise`; the import name is
+    # `import kailash`. The binding links against a Rust runtime whose source
+    # is trade secret, but install + use is free for every user.
     # Alternative: replace with `kailash-py` for the fully open-source
     # (Apache 2.0) pure-Python implementation of the same specs.
-    "kailash>=3.23.0",
+    "kailash-enterprise>=3.23.0",
     # CLI Framework
     "click>=8.0",
     "rich>=13.0.0",


### PR DESCRIPTION
## Summary

The Rust SDK Python binding ships to PyPI as **\`kailash-enterprise\`** (currently 3.23.0). The unrelated Terrene Foundation pure-Python SDK ships as **\`kailash\`** (currently 2.11.3). The template's \`pyproject.toml::dependencies\` pinned \`\"kailash>=3.23.0\"\` — wrong project AND a non-existent version of that project. Every downstream \`uv sync\` / \`pip install\` against this template fails.

The import name stays \`import kailash\` (PyO3 \`python-packages\` declaration). Only the distribution-name pin changes.

Also fixes \`.claude/skills/06-python-bindings/python-v2-quickstart.md\` which teaches the same wrong install command.

## Why this was missed

The most recent release (2.9.18) bumped the **version** \`3.20.0 → 3.23.0\` but never touched the **package name**. The fix is well-known elsewhere: \`.claude/agents/frameworks/kaizen-specialist.md:312\` already states \`NEVER use \"pip install kailash\" without \"-enterprise\" -- wrong package name\`. Only the load-bearing pin had drifted.

## Test plan

- [ ] \`uv venv && uv sync\` against the template's pyproject.toml succeeds
- [ ] \`pip install kailash-enterprise\` resolves to the 3.23.0 wheel
- [ ] \`python -c \"import kailash; print(kailash.__version__)\"\` reports a 3.x version

## Related

Surfaced from loom by user comment 2026-04-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)