### PR TITLE
fix(template): correct settings.json description to 'Rust-backed bindings' (#62)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Kailash COC Claude (Python) - Claude Code hooks configuration",
+  "description": "Kailash COC Claude (Rust-backed bindings) - Claude Code hooks configuration",
   "effortLevel": "high",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

Fix `.claude/settings.json` description string: the template targets Python/Ruby developers consuming Rust-backed Kailash bindings, not a pure-Python project.

## Diff

```diff
- "description": "Kailash COC Claude (Python) - Claude Code hooks configuration",
+ "description": "Kailash COC Claude (Rust-backed bindings) - Claude Code hooks configuration",
```

Matches `.claude/VERSION` description ("COC USE template for Python/Ruby developers using Rust-backed Kailash bindings").

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
