### PR TITLE
chore(coc): strip BUILD-internal path references from USE template

### DIFF
--- a/.claude/agents/cli-orchestrator.md
+++ b/.claude/agents/cli-orchestrator.md
@@ -82,7 +82,7 @@ The audit runs against `parity_enforcement.cross_cli_drift_audit` config at `.cl
 
 ## Full Documentation
 
-- `workspaces/multi-cli-coc/02-plans/07-loom-multi-cli-spec-v6.md` §6.2 + §4.4 + §5 — authoritative spec
+- (loom-internal reference) §6.2 + §4.4 + §5 — authoritative spec
 - `.claude/sync-manifest.yaml` → `cli_variants` + `parity_enforcement` — emission configuration (Phase E1)
 - `.claude/rules/cross-cli-parity.md` — parity contract source of truth
 - `.claude/rules/variant-authoring.md` — overlay authoring rules

--- a/.claude/agents/codex-architect.md
+++ b/.claude/agents/codex-architect.md
@@ -144,7 +144,7 @@ Per `rules/cross-cli-parity.md`:
 ## Full Documentation
 
 - `.claude/sync-manifest.yaml` → `cli_variants` + `parity_enforcement` — emission configuration
-- `workspaces/multi-cli-coc/02-plans/07-loom-multi-cli-spec-v6.md` — authoritative spec
+- (loom-internal reference) — authoritative spec
 - `.claude/rules/variant-authoring.md` — overlay authoring rules
 - `.claude/rules/cross-cli-parity.md` — parity contract
 - `.claude/codex-mcp-guard/README.md` — MCP-guard operational notes

--- a/.claude/agents/gemini-architect.md
+++ b/.claude/agents/gemini-architect.md
@@ -143,7 +143,7 @@ Per `rules/cross-cli-parity.md`:
 ## Full Documentation
 
 - `.claude/sync-manifest.yaml` → `cli_variants.context/root.md.gemini` + `parity_enforcement` — emission configuration
-- `workspaces/multi-cli-coc/02-plans/07-loom-multi-cli-spec-v6.md` — authoritative spec
+- (loom-internal reference) — authoritative spec
 - `.claude/rules/variant-authoring.md` — overlay authoring rules
 - `.claude/rules/cross-cli-parity.md` — parity contract
 - Gemini docs: [geminicli.com/docs](https://geminicli.com/docs/) (gemini-md, hooks/reference, core/subagents, cli/skills, cli/custom-commands, tools/mcp-server, reference/configuration, extensions/reference)

--- a/.claude/bin/emit.mjs
+++ b/.claude/bin/emit.mjs
@@ -595,7 +595,7 @@ export function validateSlotRoundTrip(cli, lang = null) {
 // fixture expectations. When bijection holds, write policies.json and
 // flip POLICIES_POPULATED=true in server.js.
 export function validateMcpBijectionAgainstFixtures() {
-  // Fixture moved from workspaces/multi-cli-coc/fixtures/ (gitignored)
+  // Fixture moved from (loom-internal reference) (gitignored)
   // to .claude/fixtures/ (committed) on 2026-04-22 so emit.mjs works
   // from a fresh clone. USE-template repos vendor the fixture when
   // they vendor .claude/bin/.

--- a/.claude/bin/repin-downstream.mjs
+++ b/.claude/bin/repin-downstream.mjs
@@ -269,7 +269,7 @@ function commitBody(rw) {
     `Before: template='${rw.oldTemplate}' template_repo='${rw.oldRepo}'`,
     `After:  template='${rw.newTemplate}' template_repo='${rw.newRepo}'`,
     "",
-    "See loom migration plan (workspaces/multi-cli-coc/02-plans) Phase I1.",
+    "See loom migration plan ((loom-internal reference)) Phase I1.",
   ].join("\n");
 }
 

--- a/.claude/commands/cli-audit.md
+++ b/.claude/commands/cli-audit.md
@@ -117,4 +117,4 @@ Run iteratively until zero CRITICAL and zero HIGH remain. Each iteration MUST re
 - `.claude/bin/emit.mjs` — Phase E4 emitter (V12 + V13 built-in)
 - `.claude/sync-manifest.yaml` → `cli_variants` + `parity_enforcement` — emission + audit config
 - `.claude/rules/cross-cli-parity.md` — parity contract source of truth
-- `workspaces/multi-cli-coc/02-plans/07-loom-multi-cli-spec-v6.md` §4.4 + §6.2 — authoritative dispatch contract
+- (loom-internal reference) §4.4 + §6.2 — authoritative dispatch contract

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -92,7 +92,7 @@ Write `.claude/.coc-sync-marker` per the canonical multi-CLI shape (`template`, 
 
 ## Step 9 — Project-artifact lint
 
-`node tools/lint-workspaces.js workspaces/ .session-notes 2>/dev/null || true` (advisory). Surfaces CC-native syntax leaks per `rules/cross-cli-artifact-hygiene.md`. Tool ships in the sister template; if absent, fall back to inline regex from `workspaces/multi-cli-coc/fixtures/slot-markers/emitter.mjs:279-301`.
+`node tools/lint-workspaces.js workspaces/ .session-notes 2>/dev/null || true` (advisory). Surfaces CC-native syntax leaks per `rules/cross-cli-artifact-hygiene.md`. Tool ships in the sister template; if absent, fall back to inline regex from (loom-internal reference).
 
 ## Step 10 — Verify cross-CLI surfaces
 

--- a/.claude/guides/rule-extracts/agents.md
+++ b/.claude/guides/rule-extracts/agents.md
@@ -114,15 +114,15 @@ result = Agent(prompt="Write src/feature.py with ...")
 # DO — explicit ownership in prompts
 Agent(isolation="worktree", prompt="""...resolve #546 ONNX matrix...
 Version bump + CHANGELOG:
-- packages/kailash-ml/pyproject.toml → 0.13.0
-- packages/kailash-ml/src/kailash_ml/__init__.py::__version__
-- packages/kailash-ml/CHANGELOG.md""")
+- the ml package directory pyproject.toml → 0.13.0
+- the ml package directory src/kailash_ml/__init__.py::__version__
+- the ml package directory CHANGELOG.md""")
 
 Agent(isolation="worktree", prompt="""...resolve #547+#548 km.doctor + km.track...
 COORDINATION NOTE: A parallel agent is bumping this package to 0.13.0.
-You MUST NOT edit packages/kailash-ml/pyproject.toml,
-packages/kailash-ml/src/kailash_ml/__init__.py::__version__, or
-packages/kailash-ml/CHANGELOG.md. Just deliver the functionality.""")
+You MUST NOT edit the ml package directory pyproject.toml,
+the ml package directory src/kailash_ml/__init__.py::__version__, or
+the ml package directory CHANGELOG.md. Just deliver the functionality.""")
 
 # DO NOT — silent parallel ownership
 Agent(isolation="worktree", prompt="...resolve #546... bump to 0.13.0")

--- a/.claude/guides/rule-extracts/observability.md
+++ b/.claude/guides/rule-extracts/observability.md
@@ -35,7 +35,7 @@ See 0052-DISCOVERY §2.1 and `guides/deterministic-quality/06-observability-prim
 
 ## Rule 8 — Schema-Name Hygiene: Evidence
 
-Origin: Red team review of PR #430 (2026-04-12) flagged `packages/kailash-dataflow/src/dataflow/classification/policy.py::ClassificationPolicy.classify` emitting field names at WARN level. Because log aggregators (Datadog, Splunk, CloudWatch) are typically accessible to a broader audience than the production database (SREs, on-call engineers, support staff, third-party observability vendors), a WARN containing `field=ssn` revealed that the `users` table has an `ssn` column to every log reader — even though the VALUES never leaked.
+Origin: Red team review of PR #430 (2026-04-12) flagged the dataflow package (src/dataflow/classification/policy.py::ClassificationPolicy.classify) emitting field names at WARN level. Because log aggregators (Datadog, Splunk, CloudWatch) are typically accessible to a broader audience than the production database (SREs, on-call engineers, support staff, third-party observability vendors), a WARN containing `field=ssn` revealed that the `users` table has an `ssn` column to every log reader — even though the VALUES never leaked.
 
 Downgraded to DEBUG-level in commit 62d64ac7. Operators who need to audit unclassified fields enable DEBUG for the audit window.
 

--- a/.claude/guides/rule-extracts/python-environment.md
+++ b/.claude/guides/rule-extracts/python-environment.md
@@ -67,12 +67,12 @@ pytest tests/                     # same — whose pytest?
 ```bash
 # DO — one-time setup
 uv pip install \
-  -e packages/kailash-dataflow \
-  -e packages/kailash-nexus \
-  -e packages/kailash-kaizen
+  -e packages/<sub-pkg-a> \
+  -e packages/<sub-pkg-b> \
+  -e packages/<sub-pkg-c>
 
 # DO NOT — PYTHONPATH prefix workaround
-PYTHONPATH=packages/kailash-dataflow/src:packages/kailash-nexus/src \
+PYTHONPATH=<sub-pkg-a>/src:<sub-pkg-b>/src \
   .venv/bin/python -m pytest tests/
 ```
 
@@ -90,9 +90,9 @@ PYTHONPATH=packages/kailash-dataflow/src:packages/kailash-nexus/src \
 ```toml
 # DO — editable path entry in root pyproject.toml
 [tool.uv.sources]
-kailash-dataflow = { path = "packages/kailash-dataflow", editable = true }
-kailash-nexus = { path = "packages/kailash-nexus", editable = true }
-kailash-kaizen = { path = "packages/kailash-kaizen", editable = true }
+<sub-pkg-a> = { path = "packages/<sub-pkg-a>", editable = true }
+<sub-pkg-b> = { path = "packages/<sub-pkg-b>", editable = true }
+<sub-pkg-c> = { path = "packages/<sub-pkg-c>", editable = true }
 
 # DO NOT — PyPI version pin on a sub-package you're editing locally
 [project]
@@ -116,7 +116,7 @@ Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)
 
 ```toml
 # DO — sub-packages own their test deps
-# packages/kailash-pact/pyproject.toml:
+# the pact package directory pyproject.toml:
 [project.optional-dependencies]
 test = ["hypothesis>=6.98"]
 

--- a/.claude/guides/rule-extracts/repo-scope-discipline.md
+++ b/.claude/guides/rule-extracts/repo-scope-discipline.md
@@ -29,7 +29,7 @@ $ gh issue list --repo terrene-foundation/kailash-py
 # (CWD is kailash-rs; this is the cross-repo failure mode)
 
 # DO — descriptive sibling reference in a rule body
-"This rule mirrors the Python SDK's pattern in `kailash-py/.claude/rules/foo.md`."
+"This rule mirrors the Python SDK's pattern in the sibling SDK's `.claude/rules/foo.md`."
 # (descriptive; no action proposed; no cross-repo work recommended)
 
 # DO NOT — prescriptive sibling recommendation

--- a/.claude/guides/rule-extracts/security.md
+++ b/.claude/guides/rule-extracts/security.md
@@ -59,7 +59,7 @@ Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)
 
 ## Sanitizer Contract — Exhaustive Examples
 
-DataFlow's input sanitizer (`packages/kailash-dataflow/src/dataflow/core/nodes.py::sanitize_sql_input`) is a defense-in-depth display-path safety net, NOT the primary SQLi defense. Parameter binding (`$N` / `%s` / `?`) is the primary defense.
+DataFlow's input sanitizer (the dataflow package (src/dataflow/core/nodes.py::sanitize_sql_input)) is a defense-in-depth display-path safety net, NOT the primary SQLi defense. Parameter binding (`$N` / `%s` / `?`) is the primary defense.
 
 ### 1. String Inputs Token-Replaced, Not Quote-Escaped
 
@@ -117,8 +117,8 @@ When a security-relevant kwarg (classification policy, tenant scope, clearance c
 # Helper added `policy` + `model_name` kwargs for classification sanitisation.
 #
 # $ grep -rn 'validate_model(' src/ packages/
-# packages/kailash-dataflow/src/dataflow/features/express.py:_validate_if_enabled
-# packages/kailash-dataflow/src/dataflow/engine.py::validate_record
+# the dataflow package directory src/dataflow/features/express.py:_validate_if_enabled
+# the dataflow package directory src/dataflow/engine.py::validate_record
 # tests/...  (tests covered separately)
 #
 # Both production call sites get policy+model_name in this PR:

--- a/.claude/guides/rule-extracts/testing.md
+++ b/.claude/guides/rule-extracts/testing.md
@@ -44,7 +44,7 @@ judge = MagicMock(spec=JudgeCallable)  # methods auto-generated stubs, still moc
 
 **Why:** The Protocol contract is the scripting surface, not a mock framework's `side_effect` or `return_value`. A real class declaring Protocol-required methods with correct signatures + returning real values of the Protocol-required types is a valid Tier 2 test double even when output is deterministic. A real PostgreSQL + `DeterministicJudge` are both Tier 2-legal; a mocked PostgreSQL + real OpenAI call is Tier 2 illegal.
 
-Origin: Session 2026-04-20 (issue #567 PR#5, PR#580). `DeterministicJudge` in `packages/kailash-kaizen/tests/integration/judges/test_judges_wiring.py` exercises 7 Tier 2 tests through the `kaizen.judges` facade without API keys; satisfies `kailash.diagnostics.protocols.JudgeCallable` at runtime.
+Origin: Session 2026-04-20 (issue #567 PR#5, PR#580). `DeterministicJudge` in the kaizen package (tests/integration/judges/test_judges_wiring.py) exercises 7 Tier 2 tests through the `kaizen.judges` facade without API keys; satisfies `kailash.diagnostics.protocols.JudgeCallable` at runtime.
 
 ## PR #466 — 63-Warning Sweep (2026-04-14)
 
@@ -59,7 +59,7 @@ Specific fixes:
 
 ## Pytest Plugin + Marker Declaration — 11,917-Test Block (2026-04-20)
 
-Session 2026-04-20 /redteam collection-gate sweep: `packages/kailash-kaizen/tests/e2e/memory/test_persistent_buffer_e2e.py` used `@pytest.mark.benchmark` + `benchmark` fixture without declaring `pytest-benchmark` in the sub-package's `[dev]` extras. Collection failed with:
+Session 2026-04-20 /redteam collection-gate sweep: the kaizen package (tests/e2e/memory/test_persistent_buffer_e2e.py) used `@pytest.mark.benchmark` + `benchmark` fixture without declaring `pytest-benchmark` in the sub-package's `[dev]` extras. Collection failed with:
 
 ```
 'benchmark' not found in `markers` configuration option
@@ -67,7 +67,7 @@ Session 2026-04-20 /redteam collection-gate sweep: `packages/kailash-kaizen/test
 
 ALL 11,917 kaizen tests blocked from collection until fixed. Fixed commit `1313ae56` by:
 
-1. Adding `pytest-benchmark>=4.0.0` to `packages/kailash-kaizen/pyproject.toml::[project.optional-dependencies].dev`
+1. Adding `pytest-benchmark>=4.0.0` to the kaizen package (pyproject.toml::[project.optional-dependencies].dev)
 2. Registering `benchmark: Performance benchmark tests (pytest-benchmark)` in `markers` config
 
 See `workspaces/kailash-ml-gpu-stack/journal/0008-GAP-full-specs-redteam-2026-04-20-findings.md`.
@@ -94,7 +94,7 @@ W33b fix:
 
 1. Added `trainable: Trainable | None = None` field to `TrainingResult` dataclass
 2. Every `Trainable.fit()` return site populated with `trainable=self`
-3. Landed `packages/kailash-ml/tests/regression/test_readme_quickstart_executes.py::test_readme_quickstart_executes_end_to_end` as Tier-2 E2E regression
+3. Landed the ml package (tests/regression/test_readme_quickstart_executes.py::test_readme_quickstart_executes_end_to_end) as Tier-2 E2E regression
 
 See `rules/zero-tolerance.md` §2 "Fake integration via missing handoff field" for the stub-pattern framing.
 

--- a/.claude/guides/rule-extracts/value-prioritization.md
+++ b/.claude/guides/rule-extracts/value-prioritization.md
@@ -11,10 +11,10 @@ Extended material for `rules/value-prioritization.md`. The rule itself stays at 
 | `.session-notes:34`                                                          | `coc-sync.md` 761→400-line move   | Decay (no grace clock)                       | No                                         | indefinite |
 | `.session-notes:35`                                                          | `cc-audit.md` legacy slot-keying  | Decay (no grace clock)                       | No                                         | indefinite |
 | `.session-notes:27-30`                                                       | `aggregate.mjs` probes-merge      | Decay (ownerless until current session)      | Yes (faint)                                | ~12h       |
-| `workspaces/multi-cli-coc/todos/active/00-migration-plan.md:403-452`         | Phase I1 (30+ downstream re-pins) | Decay (reframed as out-of-scope)             | Yes in v6 spec; disconnected from executor | 14 days    |
-| `workspaces/multi-cli-coc/todos/active/00-migration-plan.md:454-463`         | Phase I2 (archival 2026-10-22)    | Decay-prone (no automation, 6-month horizon) | Yes                                        | 6 months   |
-| `workspaces/multi-cli-coc/04-validate/27-todos-redteam.md:155, 233-235, 267` | Validators 1-12                   | Decay (OR-ADR escape)                        | Yes (in spec)                              | open       |
-| `workspaces/multi-cli-coc/04-validate/27-todos-redteam.md:171, 234, 269`     | Abridgement protocol              | Decay (OR-ADR escape)                        | Yes (in spec)                              | open       |
+| (loom-internal reference)         | Phase I1 (30+ downstream re-pins) | Decay (reframed as out-of-scope)             | Yes in v6 spec; disconnected from executor | 14 days    |
+| (loom-internal reference)         | Phase I2 (archival 2026-10-22)    | Decay-prone (no automation, 6-month horizon) | Yes                                        | 6 months   |
+| (loom-internal reference) | Validators 1-12                   | Decay (OR-ADR escape)                        | Yes (in spec)                              | open       |
+| (loom-internal reference)     | Abridgement protocol              | Decay (OR-ADR escape)                        | Yes (in spec)                              | open       |
 
 **Ratio: 7 decay / 0 pickup observed.** Every deferral located either (a) sits behind "no grace clock" / "downstream responsibility" / "tracked separately" framing, or (b) has an OR-escape-hatch that lets a cheaper proxy substitute for the load-bearing implementation.
 
@@ -117,7 +117,7 @@ Why this fails:
 3. **Delegated judgment** — the OR delegates the implement-vs-defer decision back to the human on every future session, which `recommendation-quality.md` MUST-1 already blocks ("no menu without pick").
 4. **Audit-trail erasure** — once the ADR statement ships, the finding is "closed" and the load-bearing implementation has no tracking artifact.
 
-Evidence: `workspaces/multi-cli-coc/04-validate/27-todos-redteam.md:155` (validators 1-12) and `:171` (abridgement protocol). Both shipped only the ADR statement, neither had the load-bearing implementation 14+ days later. Per Rule 4, recommendations MUST commit to one disposition: implement, ADR with user-gated value-decay, or close with user gate. OR-disposition is structurally indistinguishable from auto-closure-as-not-planned under another name.
+Evidence: (loom-internal reference) (validators 1-12) and `:171` (abridgement protocol). Both shipped only the ADR statement, neither had the load-bearing implementation 14+ days later. Per Rule 4, recommendations MUST commit to one disposition: implement, ADR with user-gated value-decay, or close with user gate. OR-disposition is structurally indistinguishable from auto-closure-as-not-planned under another name.
 
 ## Hook-detector fixture catalog
 

--- a/.claude/guides/rule-extracts/zero-tolerance.md
+++ b/.claude/guides/rule-extracts/zero-tolerance.md
@@ -322,7 +322,7 @@ class TrainingResult:
 
 Fix: add the missing handoff field (`trainable: Trainable | None = None`), ensure every `fit()` return site populates it, AND add an end-to-end regression test (see `rules/testing.md` § End-to-End Pipeline Regression Tests).
 
-Evidence: kailash-ml-audit 2026-04-23 W33b — `TrainingResult(frozen=True)` without `trainable` shipped in W31 + W33; `km.register` landed in W33c with no way to resolve `.model`; canonical Quick Start raised `ValueError` on every fresh install until W33b added `trainable=self` at every `Trainable.fit()` return site and landed `packages/kailash-ml/tests/regression/test_readme_quickstart_executes.py`.
+Evidence: kailash-ml-audit 2026-04-23 W33b — `TrainingResult(frozen=True)` without `trainable` shipped in W31 + W33; `km.register` landed in W33c with no way to resolve `.model`; canonical Quick Start raised `ValueError` on every fresh install until W33b added `trainable=self` at every `Trainable.fit()` return site and landed the ml package (tests/regression/test_readme_quickstart_executes.py).
 
 ### Fake Metrics
 

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -185,7 +185,7 @@ When prompting an agent with worktree isolation, the orchestrator MUST reference
 
 ```python
 # DO — relative paths resolve to the worktree's cwd
-Agent(isolation="worktree", prompt="Edit packages/kailash-ml/src/kailash_ml/trainable.py...")
+Agent(isolation="worktree", prompt="Edit the ml package directory src/kailash_ml/trainable.py...")
 # DO NOT — absolute paths bypass worktree isolation
 Agent(isolation="worktree", prompt="Edit /absolute/path/to/main-checkout/packages/...")
 ```

--- a/.claude/rules/build-repo-release-discipline.md
+++ b/.claude/rules/build-repo-release-discipline.md
@@ -190,7 +190,7 @@ for pkg_dir in packages/*/; do
 done
 
 # DO NOT — defer the check to /release
-# (Wave 4 PR #632 modified packages/kailash-mcp/src/.../auth/{providers,oauth}.py
+# (Wave 4 PR #632 modified the mcp package directory src/.../auth/{providers,oauth}.py
 #  but mcp pyproject stayed at 0.2.9. Caught only at /release-time enumeration,
 #  required a separate fix-PR #634 to bump mcp 0.2.9 → 0.2.10. Net cost:
 #  one extra PR, one extra CI cycle, one extra admin merge, ~15min of pacing.)

--- a/.claude/rules/ci-runners.md
+++ b/.claude/rules/ci-runners.md
@@ -81,7 +81,7 @@ When `Format` (or any early short-circuiting gate) transitions from red to green
 
 ### 4. Runner Auto-Update Disconnect Recovery
 
-If `gh api repos/esperie-enterprise/kailash-rs/actions/runners` returns 0 runners while the runner's stdout log tails show `Connected to GitHub` and `Listening for Jobs`, the runner auto-updated mid-session and its in-flight job is orphaned — the old worker process holds the job in GitHub's state machine but cannot report completion. The session MUST restart the runner service AND trigger a fresh run via an empty commit.
+If `gh api repos/<org>/<repo>/actions/runners` returns 0 runners while the runner's stdout log tails show `Connected to GitHub` and `Listening for Jobs`, the runner auto-updated mid-session and its in-flight job is orphaned — the old worker process holds the job in GitHub's state machine but cannot report completion. The session MUST restart the runner service AND trigger a fresh run via an empty commit.
 
 ```bash
 # DO — re-register the runner and trigger a fresh run
@@ -145,7 +145,7 @@ gh api orgs/esperie-enterprise/actions/runners \
   --jq '.runners[] | {name, busy, status}'
 
 # Step 2: cross-reference with the stuck run's jobs
-gh api repos/esperie-enterprise/kailash-rs/actions/runs/<run-id>/jobs \
+gh api repos/<org>/<repo>/actions/runs/<run-id>/jobs \
   --jq '.jobs[] | {name, status, started_at, runner_name}'
 
 # Step 3: cancel the stuck run to free the runner slot

--- a/.claude/rules/cross-cli-artifact-hygiene.md
+++ b/.claude/rules/cross-cli-artifact-hygiene.md
@@ -180,7 +180,7 @@ Mentions of "Claude Code" / "Codex" / "Gemini" MUST be qualified historically ("
 ## Trust Posture Wiring
 
 - **Severity:** `advisory` for all 5 MUST clauses. Lint reports leaks; user adjudicates rewrite vs qualify. Workspace artifacts are session records; advisory severity matches CARE Principle 7 graduated-trust posture for content that affects framing without affecting runtime directly.
-- **Grace period:** 14 days. Existing artifacts in `kailash-py/workspaces/` and `kailash-rs/workspaces/` carry pre-rule leakage; lint surfaces them as advisory until swept.
+- **Grace period:** 14 days. Existing workspace artifacts may carry pre-rule leakage; lint surfaces them as advisory until swept.
 - **Regression-within-grace:** any new artifact authored after rule-land that introduces a flagged pattern triggers `regression_within_grace` per `trust-posture.md` MUST Rule 4. New leaks are loud; old leaks are advisory.
 - **Receipt requirement:** none — rule is path-scoped to artifact paths and surfaces via `tools/lint-workspaces.js` + `/cli-audit` Phase 4.
 - **Detection mechanism:** `node tools/lint-workspaces.js workspaces/` enumerates artifacts and greps for the BLOCKED patterns from MUST clauses 1–5. `/cli-audit` Phase 4 invokes the same lint. Fixtures at `.claude/audit-fixtures/cross-cli-artifact-hygiene/` exercise every flag + every clean-pass case.

--- a/.claude/rules/cross-cli-parity.md
+++ b/.claude/rules/cross-cli-parity.md
@@ -14,7 +14,7 @@ Loom emits the same underlying artifact (rule / agent / skill / command) to thre
 
 Parity violations don't fail at emit time — they fail at user time, when a rule shipped to Codex is quietly weaker than the same rule shipped to CC.
 
-Origin: `workspaces/multi-cli-coc/02-plans/04-loom-multi-cli-spec-v3.md` §4.5 + §6.2 `cli-orchestrator.sees` verb, authored after round-2 portability reviewer flagged missing contract.
+Origin: (loom-internal reference) §4.5 + §6.2 `cli-orchestrator.sees` verb, authored after round-2 portability reviewer flagged missing contract.
 
 ## MUST Rules
 
@@ -122,6 +122,6 @@ scrub_tokens: ["MUST", "never", "always", "WARN"]  # hides real drift
 
 **Why:** A disabled audit produces no findings; the drift ships silently and is unrecoverable once downstream repos pull it.
 
-Origin: `workspaces/multi-cli-coc/02-plans/04-loom-multi-cli-spec-v3.md` §4.5 + §6.2 + round-2 aggregate `04-validate/10-round-2-aggregate.md`.
+Origin: (loom-internal reference) §4.5 + §6.2 + round-2 aggregate `04-validate/10-round-2-aggregate.md`.
 
 <!-- /slot:neutral-body -->

--- a/.claude/rules/infrastructure-sql.md
+++ b/.claude/rules/infrastructure-sql.md
@@ -155,7 +155,7 @@ def test_dataflow_importable_without_motor(monkeypatch):
 
 **Why:** Without a behavioral test the pattern is only human-enforced. The MongoDB adapter regression that motivated this rule had passed code review — the lazy pattern only surfaced when a downstream Docker build died on missing motor.
 
-Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-11) — `packages/kailash-dataflow/src/dataflow/adapters/mongodb.py` imported `motor.motor_asyncio` at module top, breaking `from dataflow import DataFlow` for every non-MongoDB project.
+Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-11) — the dataflow package (src/dataflow/adapters/mongodb.py) imported `motor.motor_asyncio` at module top, breaking `from dataflow import DataFlow` for every non-MongoDB project.
 
 ## MUST NOT
 

--- a/.claude/rules/python-environment.md
+++ b/.claude/rules/python-environment.md
@@ -70,12 +70,12 @@ When a repo contains `packages/*/pyproject.toml`, every sub-package MUST be inst
 ```bash
 # DO — one-time setup
 uv pip install \
-  -e packages/kailash-dataflow \
-  -e packages/kailash-nexus \
-  -e packages/kailash-kaizen
+  -e packages/<sub-pkg-a> \
+  -e packages/<sub-pkg-b> \
+  -e packages/<sub-pkg-c>
 
 # DO NOT — PYTHONPATH prefix workaround
-PYTHONPATH=packages/kailash-dataflow/src:packages/kailash-nexus/src \
+PYTHONPATH=<sub-pkg-a>/src:<sub-pkg-b>/src \
   .venv/bin/python -m pytest tests/
 ```
 
@@ -90,7 +90,7 @@ Root `pyproject.toml` constraints on monorepo sub-packages MUST be expressed as 
 ```toml
 # DO — editable path entry in root pyproject.toml
 [tool.uv.sources]
-kailash-dataflow = { path = "packages/kailash-dataflow", editable = true }
+<sub-pkg-a> = { path = "packages/<sub-pkg-a>", editable = true }
 
 # DO NOT — PyPI version pin on a sub-package you're editing locally
 [project]
@@ -111,7 +111,7 @@ A dev dependency declared by a sub-package (`packages/*/pyproject.toml`) MUST NO
 
 ```toml
 # DO — sub-packages own their test deps
-# packages/kailash-pact/pyproject.toml:
+# the pact package directory pyproject.toml:
 [project.optional-dependencies]
 test = ["hypothesis>=6.98"]
 # root pyproject.toml [dev]: (no hypothesis entry)

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -120,7 +120,7 @@ All user-generated content MUST be encoded before display in HTML templates, JSO
 
 ## Sanitizer Contract — DataFlow Display Hygiene
 
-DataFlow's input sanitizer (`packages/kailash-dataflow/src/dataflow/core/nodes.py::sanitize_sql_input`) is a defense-in-depth display-path safety net, NOT the primary SQLi defense. Parameter binding (`$N` / `%s` / `?`) is the primary defense — see § Parameterized Queries above.
+DataFlow's input sanitizer (the dataflow package (src/dataflow/core/nodes.py::sanitize_sql_input)) is a defense-in-depth display-path safety net, NOT the primary SQLi defense. Parameter binding (`$N` / `%s` / `?`) is the primary defense — see § Parameterized Queries above.
 
 ### 1. String Inputs MUST Be Token-Replaced, Not Quote-Escaped
 

--- a/.claude/rules/value-prioritization.md
+++ b/.claude/rules/value-prioritization.md
@@ -105,7 +105,7 @@ At the start of any session that picks up a deferred item (workspace todo, GH fo
 
 Picking up `feat/codex-gemini-lane-validation` (deferred 2026-04-23).
 Recorded anchor: "delivers multi-CLI parity per v6 §9.2 brief."
-Re-validation: brief still active per workspaces/multi-cli-coc/briefs/?
+Re-validation: brief still active per (loom-internal reference)
 User's most recent feedback referenced multi-CLI as in-flight — anchor
 holds. Resuming.
 
@@ -149,7 +149,7 @@ explicit ADR statement that they are shell one-liners.
 
 **BLOCKED OR-escape-hatch variants** — the ONLY legitimate dispositions are (1) implement now with value-anchored shards, (2) ADR with user-gated value-decay, (3) close with user gate. ANY OR-disposition that introduces a fourth option is BLOCKED regardless of framing: "Add X OR file follow-up issue / OR document as known limitation / OR mark as deferred-with-rationale / OR capture in roadmap / OR create observability / OR add a smoke test asserting current behavior / OR add to /redteam checklist / Implement-OR-spec-only / Code-OR-doc / Fix-OR-monitor." Each substitutes a cheaper proxy for the load-bearing implementation; the cheaper proxy ALWAYS wins. Full enumeration in guide-extract.
 
-**Why:** The user's value rationale is the load-bearing claim that the work matters. Closing without re-validating is the terminal step in deferral-as-forgetting: the item disappears from the queue, the rationale disappears from the audit trail, and the next time the user asks "did we ever address X?" the answer is "we closed it 60 days ago." The user gate is the only mechanism that catches value-still-applies before closure becomes institutional fact. Evidence (Failure-A audit 2026-05-07): 7-of-7 deferred items inspected showed decay-not-pickup; 2 of 7 used the OR-escape-hatch (`workspaces/multi-cli-coc/04-validate/27-todos-redteam.md:155, 171`); both shipped only the ADR statement, neither had the load-bearing implementation 14+ days later.
+**Why:** The user's value rationale is the load-bearing claim that the work matters. Closing without re-validating is the terminal step in deferral-as-forgetting: the item disappears from the queue, the rationale disappears from the audit trail, and the next time the user asks "did we ever address X?" the answer is "we closed it 60 days ago." The user gate is the only mechanism that catches value-still-applies before closure becomes institutional fact. Evidence (Failure-A audit 2026-05-07): 7-of-7 deferred items inspected showed decay-not-pickup; 2 of 7 used the OR-escape-hatch ((loom-internal reference)); both shipped only the ADR statement, neither had the load-bearing implementation 14+ days later.
 
 ### 5. Brief / User-Stated Value Is The Primary Anchor; Code-Health Is Secondary
 
@@ -255,7 +255,7 @@ picking based on functionality count.
 
 ## Origin
 
-**Primary** (Failure-A: deferral-as-forgetting): 2026-04-23 — `workspaces/multi-cli-coc/todos/active/00-migration-plan.md:403-452` reframed v6 §9.2 step 23 (30+ downstream re-pin obligation) from "loom task" to "downstream responsibility — loom does not sweep these," citing prior feedback memory as authority. Failure-A audit (2026-05-07) confirmed 7-of-7 decay-not-pickup ratio across deferred items inspected; OR-escape-hatch pattern in 2 of 7.
+**Primary** (Failure-A: deferral-as-forgetting): 2026-04-23 — (loom-internal reference) reframed v6 §9.2 step 23 (30+ downstream re-pin obligation) from "loom task" to "downstream responsibility — loom does not sweep these," citing prior feedback memory as authority. Failure-A audit (2026-05-07) confirmed 7-of-7 decay-not-pickup ratio across deferred items inspected; OR-escape-hatch pattern in 2 of 7.
 
 **Corroboration** (Failure-B: streetlight selection): 2026-05-07 loom session — agent picked aggregator-merge `.probes.jsonl` follow-up over THREE Carried-forward candidates (`coc-sync.md` move, `cc-audit.md` slot-keying, Codex/Gemini lane re-validation per multi-CLI parity brief). Pick rationale: "open follow-up before grace deadline / fixes a latent bug / cheap (~150 LOC)." User directive landing this rule: "the codegen fails to prioritize on VALUE to the USER, and chooses tasks that are small, can fit into shard. Across multiple iterations and context, the value got lost and we go into spiral and we lose the forest for the trees." Extended evidence + 12-phrase BLOCKED-rationalization corpus + OR-escape-hatch detail in `.claude/guides/rule-extracts/value-prioritization.md`.
 

--- a/.claude/rules/variant-authoring.md
+++ b/.claude/rules/variant-authoring.md
@@ -14,7 +14,7 @@ Loom's variant system has two axes: **language** (`py`/`rs`/`rb`/`prism`) and **
 
 Authoring a variant wrong doesn't fail at author time — it fails at emit time across every downstream USE template. One bad overlay desynchronises N × M targets.
 
-Origin: `workspaces/multi-cli-coc/02-plans/04-loom-multi-cli-spec-v3.md` §3, authored after round-2 convergence flagged a missing contract.
+Origin: (loom-internal reference) §3, authored after round-2 convergence flagged a missing contract.
 
 ## MUST Rules
 
@@ -151,6 +151,6 @@ variants/py-codex/rules/zero-tolerance.md # zero-tolerance's neutral body is CLI
 
 **Why:** Unresolved variants accumulate; /sync distributes them unchanged; downstream repos inherit the mess.
 
-Origin: `workspaces/multi-cli-coc/02-plans/04-loom-multi-cli-spec-v3.md` §3 + round-2 aggregate `04-validate/10-round-2-aggregate.md`.
+Origin: (loom-internal reference) §3 + round-2 aggregate `04-validate/10-round-2-aggregate.md`.
 
 <!-- /slot:neutral-body -->

--- a/.claude/skills/02-dataflow/dataflow-derived-models.md
+++ b/.claude/skills/02-dataflow/dataflow-derived-models.md
@@ -151,5 +151,5 @@ At `db.initialize()`, the engine runs DFS cycle detection across all derived mod
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/features/derived.py` -- DerivedModelEngine, scheduler, cycle detection
-- `packages/kailash-dataflow/tests/unit/test_derived_model.py` -- Unit tests
+- the dataflow package (src/dataflow/features/derived.py) -- DerivedModelEngine, scheduler, cycle detection
+- the dataflow package (tests/unit/test_derived_model.py) -- Unit tests

--- a/.claude/skills/02-dataflow/dataflow-events.md
+++ b/.claude/skills/02-dataflow/dataflow-events.md
@@ -109,5 +109,5 @@ The `on_source_change` refresh mode subscribes to all 8 WRITE_OPERATIONS for eac
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/core/events.py` -- DataFlowEventMixin, WRITE_OPERATIONS
-- `packages/kailash-dataflow/tests/unit/features/test_dataflow_events.py` -- Unit tests
+- the dataflow package (src/dataflow/core/events.py) -- DataFlowEventMixin, WRITE_OPERATIONS
+- the dataflow package (tests/unit/features/test_dataflow_events.py) -- Unit tests

--- a/.claude/skills/02-dataflow/dataflow-express-cache.md
+++ b/.claude/skills/02-dataflow/dataflow-express-cache.md
@@ -106,6 +106,6 @@ class MyCustomCache:
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/features/express.py` -- Cache integration in Express API
-- `packages/kailash-dataflow/src/dataflow/cache/invalidation.py` -- CacheBackendProtocol
-- `packages/kailash-dataflow/tests/unit/test_express_cache_wiring.py` -- Cache wiring tests
+- the dataflow package (src/dataflow/features/express.py) -- Cache integration in Express API
+- the dataflow package (src/dataflow/cache/invalidation.py) -- CacheBackendProtocol
+- the dataflow package (tests/unit/test_express_cache_wiring.py) -- Cache wiring tests

--- a/.claude/skills/02-dataflow/dataflow-file-import.md
+++ b/.claude/skills/02-dataflow/dataflow-file-import.md
@@ -108,5 +108,5 @@ CSV, TSV, JSON, and JSONL use stdlib only -- no extra dependencies.
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/nodes/file_source.py` -- FileSourceNode
-- `packages/kailash-dataflow/tests/unit/test_file_source_node.py` -- Unit tests
+- the dataflow package (src/dataflow/nodes/file_source.py) -- FileSourceNode
+- the dataflow package (tests/unit/test_file_source_node.py) -- Unit tests

--- a/.claude/skills/02-dataflow/dataflow-ml-integration.md
+++ b/.claude/skills/02-dataflow/dataflow-ml-integration.md
@@ -121,8 +121,8 @@ All converters handle categoricals, nulls, and dtype preservation.
 
 ## Cross-References
 
-- `packages/kailash-ml/src/kailash_ml/engines/feature_store.py` -- FeatureStore implementation
-- `packages/kailash-ml/src/kailash_ml/engines/_feature_sql.py` -- All SQL in one module
-- `packages/kailash-ml/src/kailash_ml/interop.py` -- Polars conversion module
+- the ml package (src/kailash_ml/engines/feature_store.py) -- FeatureStore implementation
+- the ml package (src/kailash_ml/engines/_feature_sql.py) -- All SQL in one module
+- the ml package (src/kailash_ml/interop.py) -- Polars conversion module
 - `rules/infrastructure-sql.md` -- SQL safety patterns (identifier validation, transactions)
 - `rules/dataflow-pool.md` -- Connection pool rules (no separate ConnectionManagers)

--- a/.claude/skills/02-dataflow/dataflow-read-replicas.md
+++ b/.claude/skills/02-dataflow/dataflow-read-replicas.md
@@ -77,5 +77,5 @@ health = await db.health_check()
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/core/engine.py` -- Read replica init (TSG-105)
-- `packages/kailash-dataflow/src/dataflow/features/express.py` -- `use_primary` parameter on reads
+- the dataflow package (src/dataflow/core/engine.py) -- Read replica init (TSG-105)
+- the dataflow package (src/dataflow/features/express.py) -- `use_primary` parameter on reads

--- a/.claude/skills/02-dataflow/dataflow-retention.md
+++ b/.claude/skills/02-dataflow/dataflow-retention.md
@@ -115,5 +115,5 @@ result.error          # None or error message
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/features/retention.py` -- RetentionEngine
-- `packages/kailash-dataflow/tests/unit/test_retention_engine.py` -- Unit tests
+- the dataflow package (src/dataflow/features/retention.py) -- RetentionEngine
+- the dataflow package (tests/unit/test_retention_engine.py) -- Unit tests

--- a/.claude/skills/02-dataflow/dataflow-validation-dsl.md
+++ b/.claude/skills/02-dataflow/dataflow-validation-dsl.md
@@ -72,5 +72,5 @@ Keys starting with `_` are reserved for config (e.g., `_config`).
 
 ## Source Code
 
-- `packages/kailash-dataflow/src/dataflow/validation/dsl.py` -- Parser
-- `packages/kailash-dataflow/tests/unit/test_validation_dsl.py` -- Unit tests
+- the dataflow package (src/dataflow/validation/dsl.py) -- Parser
+- the dataflow package (tests/unit/test_validation_dsl.py) -- Unit tests

--- a/.claude/skills/04-kaizen/kaizen-agent-reference.md
+++ b/.claude/skills/04-kaizen/kaizen-agent-reference.md
@@ -22,4 +22,4 @@ When this guidance is insufficient, consult:
 
 - `.claude/skills/04-kaizen/` - Complete Kaizen skills directory
 - `.claude/skills/04-kaizen/kaizen-advanced-patterns.md` - Advanced patterns
-- `packages/kailash-kaizen/examples/` - Working examples
+- the kaizen package (examples/) - Working examples

--- a/.claude/skills/04-kaizen/kaizen-ml-integration.md
+++ b/.claude/skills/04-kaizen/kaizen-ml-integration.md
@@ -145,6 +145,6 @@ See `skills/02-dataflow/dataflow-ml-integration.md` for the full converter table
 ## Cross-References
 
 - `skills/02-dataflow/dataflow-ml-integration.md` -- FeatureStore + DataFlow integration details
-- `packages/kailash-ml/src/kailash_ml/engines/` -- Engine implementations
-- `packages/kailash-ml/src/kailash_ml/interop.py` -- Polars converters
+- the ml package (src/kailash_ml/engines/) -- Engine implementations
+- the ml package (src/kailash_ml/interop.py) -- Polars converters
 - `rules/infrastructure-sql.md` -- SQL safety patterns used by FeatureStore/ModelRegistry

--- a/.claude/skills/15-enterprise-infrastructure/scheduler-patterns.md
+++ b/.claude/skills/15-enterprise-infrastructure/scheduler-patterns.md
@@ -2,7 +2,7 @@
 
 You are an expert in Kailash's scheduling primitives — `WorkflowScheduler` (general-purpose cron / interval / one-shot) and `FabricScheduler` (DataFlow product-refresh cron). Guide users through engagement, migration from external cron, and the multi-instance hazards.
 
-> Source: `src/kailash/runtime/scheduler.py` (`WorkflowScheduler`), `packages/kailash-dataflow/src/dataflow/fabric/scheduler.py` (`FabricScheduler`).
+> Source: `src/kailash/runtime/scheduler.py` (`WorkflowScheduler`), the dataflow package (src/dataflow/fabric/scheduler.py) (`FabricScheduler`).
 
 ## When to Engage
 

--- a/.claude/skills/30-claude-code-patterns/multi-cli-migration.md
+++ b/.claude/skills/30-claude-code-patterns/multi-cli-migration.md
@@ -217,7 +217,7 @@ Surface CC-native syntax leaks in workspaces/journals/briefs/todos/.session-note
 node tools/lint-workspaces.js workspaces/ .session-notes 2>/dev/null || true   # advisory
 ```
 
-If `tools/lint-workspaces.js` is absent (project predates v2.23.x), inline the regex set from `workspaces/multi-cli-coc/fixtures/slot-markers/emitter.mjs:279-301`:
+If `tools/lint-workspaces.js` is absent (project predates v2.23.x), inline the regex set from (loom-internal reference):
 
 - `Agent\([^)]*subagent_type` (CC delegation)
 - `Agent\([^)]*run_in_background`

--- a/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
+++ b/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
@@ -69,7 +69,7 @@ Before merging a worktree branch, check if its merge-base is older than the targ
 
 ```bash
 # For each worktree about to merge, compare LOC of shared files
-TARGET_FILE="packages/kailash-kaizen/src/kaizen/core/base_agent.py"
+TARGET_FILE="the kaizen package directory src/kaizen/core/base_agent.py"
 for wt in .claude/worktrees/agent-*/; do
     wt_file="${wt}${TARGET_FILE}"
     [ -f "$wt_file" ] || continue

--- a/.claude/skills/30-claude-code-patterns/worktree-orchestration.md
+++ b/.claude/skills/30-claude-code-patterns/worktree-orchestration.md
@@ -42,8 +42,8 @@ Agent(
     Resolve <issue>.
 
     Files you may edit (relative paths only; NEVER absolute):
-    - packages/kailash-ml/src/kailash_ml/foo.py
-    - packages/kailash-ml/tests/integration/test_foo.py
+    - the ml package directory src/kailash_ml/foo.py
+    - the ml package directory tests/integration/test_foo.py
 
     ...
     """,
@@ -110,7 +110,7 @@ The `ls` check is O(1) and converts silent no-op into loud retry.
 Session 2026-04-20 kailash-ml 0.13.0 + kailash 2.8.10 parallel-release cycle (PRs #552, #553). Three parallel worktree agents resolved issues #546 (ONNX matrix), #547+#548 (km.doctor + km.track), and #550 (quote_identifier). Clean integration because:
 
 - **Agent 1** designated version-owner for kailash-ml pyproject.toml + CHANGELOG
-- **Agent 2** prompt included the verbatim exclusion: "COORDINATION NOTE: A parallel agent is resolving #546 (ONNX bridge matrix) in another worktree and will ALSO bump version to 0.13.0 + write CHANGELOG. To avoid merge conflicts, you (this agent) MUST NOT edit packages/kailash-ml/pyproject.toml, packages/kailash-ml/src/kailash_ml/**init**.py::**version**, or packages/kailash-ml/CHANGELOG.md."
+- **Agent 2** prompt included the verbatim exclusion: "COORDINATION NOTE: A parallel agent is resolving #546 (ONNX bridge matrix) in another worktree and will ALSO bump version to 0.13.0 + write CHANGELOG. To avoid merge conflicts, you (this agent) MUST NOT edit the ml package directory pyproject.toml, the ml package directory src/kailash_ml/**init**.py::**version**, or the ml package directory CHANGELOG.md."
 - **Agent 3** worked on a different package (core kailash/, 2.8.10) — no overlap
 
 Result: merge integration was mechanical. One trivial CHANGELOG conflict on the root file, zero conflicts on package pyproject.toml or package CHANGELOG. Integration step (owned by orchestrator) added `km-doctor` console script + expanded CHANGELOG (which Agent 1 correctly seeded with ONNX entries only) to cover all three issues.

--- a/.claude/skills/34-kailash-ml/m1-release-wave.md
+++ b/.claude/skills/34-kailash-ml/m1-release-wave.md
@@ -90,7 +90,7 @@ Origin: W33b shard, spec §16.3 fingerprint contract.
 
 ## MIGRATION.md Sunset Contract (W33b)
 
-W33b landed `packages/kailash-ml/MIGRATION.md` documenting the 0.x → 1.0.0 breaking surface:
+W33b landed the ml package (MIGRATION.md) documenting the 0.x → 1.0.0 breaking surface:
 
 - Legacy status vocabulary (`SUCCESS`, `COMPLETED`) hard-migrated to `FINISHED` at install (Decision 1)
 - Raw sklearn/torch training loops blocked via `UnsupportedTrainerError` (Decision 8)

--- a/.claude/skills/36-kailash-rs-alignment/crate-structure.md
+++ b/.claude/skills/36-kailash-rs-alignment/crate-structure.md
@@ -3,7 +3,7 @@
 ## Workspace Layout (~46 crates)
 
 ```
-kailash-rs/
+<workspace-root>/
 ├── crates/
 │   ├── kailash-core/          ← Node system, workflow builder, runtime, EventBus, AuditLog
 │   ├── kailash-dataflow/      ← Database ORM, models, CRUD, query engine, classification

--- a/.claude/variants/rs/rules/ci-runners.md
+++ b/.claude/variants/rs/rules/ci-runners.md
@@ -76,7 +76,7 @@ When `Format` (or any early short-circuiting gate) transitions from red to green
 
 ### 4. Runner Auto-Update Disconnect Recovery
 
-If `gh api repos/esperie-enterprise/kailash-rs/actions/runners` returns 0 runners while the runner's stdout log tails show `Connected to GitHub` and `Listening for Jobs`, the runner auto-updated mid-session and its in-flight job is orphaned — the old worker process holds the job in GitHub's state machine but cannot report completion. The session MUST restart the runner service AND trigger a fresh run via an empty commit.
+If `gh api repos/<org>/<repo>/actions/runners` returns 0 runners while the runner's stdout log tails show `Connected to GitHub` and `Listening for Jobs`, the runner auto-updated mid-session and its in-flight job is orphaned — the old worker process holds the job in GitHub's state machine but cannot report completion. The session MUST restart the runner service AND trigger a fresh run via an empty commit.
 
 ```bash
 # DO — re-register the runner and trigger a fresh run
@@ -140,7 +140,7 @@ gh api orgs/esperie-enterprise/actions/runners \
   --jq '.runners[] | {name, busy, status}'
 
 # Step 2: cross-reference with the stuck run's jobs
-gh api repos/esperie-enterprise/kailash-rs/actions/runs/<run-id>/jobs \
+gh api repos/<org>/<repo>/actions/runs/<run-id>/jobs \
   --jq '.jobs[] | {name, status, started_at, runner_name}'
 
 # Step 3: cancel the stuck run to free the runner slot


### PR DESCRIPTION
## Summary

Surgical strip of BUILD-internal absolute paths from `.claude/` artifacts that USE template consumers cannot resolve. Same scope as terrene-foundation/kailash-coc-rs#25, applied here for the CC-only Rust template.

Single atomic commit (42 files) covering:

1. **`workspaces/multi-cli-coc/...` (13 occurrences)** — loom-internal workspace citations rewritten to `(loom-internal reference)` neutral annotation; bin-script source comments neutralised.

2. **`packages/kailash-*/src|tests/...` (25-file surface)** — bulk sed converted `packages/kailash-X/path/to/file.py` to `the X package (path/to/file.py)` and bare path prefixes to `the X package directory `. PyPI dependency-spec names kept. Install-block examples in `python-environment.md` rewritten with `<sub-pkg-a>` placeholders.

3. **`kailash-rs/` / `kailash-py/` / `kailash-prism/` repo prefixes (5 occurrences)** — `gh api repos/<org>/kailash-rs/...` rewritten to `repos/<org>/<repo>/...`; descriptive `kailash-py/` example neutralised; `kailash-rs/` workspace-root label in `crate-structure.md` replaced with `<workspace-root>/`. The variant overlay `.claude/variants/rs/rules/ci-runners.md` also fixed.

## Coverage

| Pattern | Pre | Post |
|---|---|---|
| `workspaces/multi-cli-coc/` | 13 | 0 |
| `packages/kailash-*/` | 25 | 0 |
| `kailash-rs/` / `kailash-py/` / `kailash-prism/` repo prefix | 5 | 0 |
| `crates/kailash-*/` | 81 | 81 (KEPT — illustrative for binding consumers per contract) |

## Scope discipline

- All edits inside `.claude/`. CLAUDE.md (template-owned), `.coc-obsoleted`, VERSION, sync-manifest.yaml, `.coc-sync-marker`, `.claude/learning/` untouched.
- No re-sync from loom; surgical edits only.
- Explicit-paths staging (42 files via `xargs git add --`).

## Test plan

- [ ] Verify CC SessionStart loads `.claude/` without errors after merge
- [ ] Verify no broken backticks / unclosed markdown blocks introduced by bulk sed
- [ ] Verify `crates/kailash-*/` skill bodies still read coherently for binding consumers