### PR TITLE
fix(coc): add YAML frontmatter to 8 SKILL.md files lacking it

### DIFF
--- a/.claude/skills/01-core-sdk/SKILL.md
+++ b/.claude/skills/01-core-sdk/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: core-sdk
+description: "Kailash Core SDK (Rust) — workspace crate map (value/core/nodes/macros/plugin), 139+ nodes, WorkflowBuilder, AuditLog, EventBus. Use for crate navigation + node patterns."
+---
+
 # Kailash Workspace Crate Reference
 
 Quick reference for all crates in the workspace. For full API docs, read the crate source or run `cargo doc --workspace --no-deps`.

--- a/.claude/skills/02-dataflow/SKILL.md
+++ b/.claude/skills/02-dataflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dataflow
+description: "Kailash DataFlow (Rust) — MANDATORY for DB/CRUD/bulk/migrations via sqlx + ModelDefinition. Raw SQL BLOCKED."
+---
+
 # DataFlow Skills Index
 
 Skills for `kailash-dataflow` -- the database framework built on kailash-core and sqlx.

--- a/.claude/skills/04-kaizen/SKILL.md
+++ b/.claude/skills/04-kaizen/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: kaizen
+description: "Kailash Kaizen (Rust) — MANDATORY for AI agents/signatures/RAG via kailash-kaizen crate. Custom LLM agents BLOCKED."
+---
+
 # Kaizen Skills
 
 AI agent framework for building intelligent agents with kailash-enterprise.

--- a/.claude/skills/31-l3-autonomy/SKILL.md
+++ b/.claude/skills/31-l3-autonomy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: l3-autonomy
+description: "L3 agent autonomy primitives (Rust) — envelope tracking, context scoping, messaging, agent factory, plan DAG, enforcement pipeline. For governed multi-agent systems."
+---
+
 # 31-l3-autonomy: L3 Agent Autonomy Primitives
 
 Feature flags: `l3-core` (sync types, WASM-compatible), `l3` (full runtime, requires tokio)

--- a/.claude/skills/32-kaizen-agents/SKILL.md
+++ b/.claude/skills/32-kaizen-agents/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: kaizen-agents
+description: "kaizen-agents crate (Rust) — LLM-driven orchestration: decomposer, designer, composer, monitor, recomposer, delegation. SDK/orchestration boundary, governed by kailash-pact."
+---
+
 # 32-kaizen-agents: LLM-Powered Agent Orchestration
 
 Crate location: `crates/kaizen-agents/`

--- a/.claude/skills/33-gsf-cap/SKILL.md
+++ b/.claude/skills/33-gsf-cap/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: gsf-cap
+description: "GSF CAP features (Rust v3.3) — audit chain, domain event bus, enterprise middleware, data classification, field validation, query telemetry across kailash-core/nexus/dataflow."
+---
+
 # GSF CAP Features
 
 Eight governance, security, and framework capabilities implemented across four crates in the v3.3 workspace.

--- a/.claude/skills/34-kailash-ml/SKILL.md
+++ b/.claude/skills/34-kailash-ml/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: kailash-ml
+description: "Kailash ML (Rust) — MANDATORY for ML training/inference/drift via kailash-ml crate. Raw linfa/burn use BLOCKED."
+---
+
 # kailash-ml — Classical ML Framework (Rust)
 
 20-crate workspace providing scikit-learn-equivalent algorithms with Rust performance. 90+ estimator types, 62 EstimatorRegistry entries, TransformerRegistry, rayon parallelism. All crates proprietary (`publish = false`).

--- a/.claude/skills/36-kailash-rs-alignment/SKILL.md
+++ b/.claude/skills/36-kailash-rs-alignment/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: kailash-rs-alignment
+description: "Kailash RS alignment reference — 20-crate workspace layout, ML crate patterns, PyO3 bindings, transport parity, cross-SDK feature table for kailash-rs contributors."
+---
+
 # Kailash RS Alignment — Cross-SDK Reference
 
 Workspace architecture, ML crate patterns, binding conventions, and cross-SDK parity reference for kailash-rs contributors.


### PR DESCRIPTION
## Summary

Add YAML frontmatter to 8 `.claude/skills/*/SKILL.md` files that lack it entirely (start with markdown `# Heading`, not `---`). CC's skill listing surfaces them with 0-char descriptions, consuming slots without semantic value.

| File | Lines | Description chars |
|---|---|---|
| `01-core-sdk` | 90 | 170 |
| `02-dataflow` | 69 | 110 |
| `04-kaizen` | 105 | 115 |
| `31-l3-autonomy` | 60 | 170 |
| `32-kaizen-agents` | 149 | 180 |
| `33-gsf-cap` | 46 | 185 |
| `34-kailash-ml` | 421 | 115 |
| `36-kailash-rs-alignment` | 13 | 170 |

8 files / 40 insertions.

## Pairing

Matches loom-side fix [terrene-foundation/loom#197](https://github.com/esperie-enterprise/loom/pull/197). Pre-empts the next `/sync rs` cycle so the broken listing state is fixed immediately in this USE template.

Surfaced 2026-05-14 via coursewright skill-bloat audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)